### PR TITLE
feat: Add Category entity with CRUD operations

### DIFF
--- a/server/src/__tests__/integration/category.integration.test.ts
+++ b/server/src/__tests__/integration/category.integration.test.ts
@@ -1,0 +1,305 @@
+import request from 'supertest';
+import app from '../../app';
+import { Category } from '../../models/Category';
+import { User } from '../../models/User';
+import { Session } from '../../models/Session';
+import { sequelize } from '../../db/sequelize';
+import { initDatabase } from '../../db/sequelize';
+import { 
+  generateTestToken,
+  hashTestToken,
+  cleanupAuth
+} from '../fixtures/auth.fixtures';
+import { 
+  userFixtures, 
+  createUserInDb,
+  cleanupUsers
+} from '../fixtures/user.fixtures';
+
+// Fonction de nettoyage
+const cleanupCategories = async (): Promise<void> => {
+  await Category.destroy({ where: {}, force: true });
+};
+
+const cleanupUsers = async (): Promise<void> => {
+  await User.destroy({ where: {}, force: true });
+};
+
+const cleanupAuth = async (): Promise<void> => {
+  await Session.destroy({ where: {}, force: true });
+};
+
+describe('Category Integration Tests', () => {
+  let adminUser: User;
+  let adminToken: string;
+  let adminSession: Session;
+
+  beforeAll(async () => {
+    await initDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanupCategories();
+    await cleanupUsers();
+    await cleanupAuth();
+
+    // Créer un utilisateur admin
+    adminUser = await createUserInDb(userFixtures.admin);
+    adminToken = generateTestToken(adminUser.id);
+    const adminTokenHash = await hashTestToken(adminToken);
+    adminSession = await Session.create({
+      userId: adminUser.id,
+      tokenHash: adminTokenHash,
+      ipAddress: '127.0.0.1',
+      userAgent: 'Mozilla/5.0 (Test Browser)',
+      isActive: true,
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupCategories();
+    await cleanupUsers();
+    await cleanupAuth();
+  });
+
+  describe('Complete Category Workflow', () => {
+    it('should handle complete category lifecycle', async () => {
+      // 1. Créer une catégorie
+      const createResponse = await request(app)
+        .post('/api/categories')
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send({
+          name: 'Technology',
+          description: 'Articles about technology and innovation'
+        })
+        .expect(201);
+
+      expect(createResponse.body.success).toBe(true);
+      expect(createResponse.body.data.name).toBe('Technology');
+      const categoryId = createResponse.body.data.id;
+
+      // 2. Récupérer la catégorie créée
+      const getResponse = await request(app)
+        .get(`/api/categories/${categoryId}`)
+        .expect(200);
+
+      expect(getResponse.body.success).toBe(true);
+      expect(getResponse.body.data.id).toBe(categoryId);
+      expect(getResponse.body.data.name).toBe('Technology');
+
+      // 3. Lister toutes les catégories
+      const listResponse = await request(app)
+        .get('/api/categories')
+        .expect(200);
+
+      expect(listResponse.body.success).toBe(true);
+      expect(listResponse.body.data.data).toHaveLength(1);
+      expect(listResponse.body.data.data[0].name).toBe('Technology');
+
+      // 4. Mettre à jour la catégorie
+      const updateResponse = await request(app)
+        .put(`/api/categories/${categoryId}`)
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send({
+          name: 'Advanced Technology',
+          description: 'Articles about cutting-edge technology'
+        })
+        .expect(200);
+
+      expect(updateResponse.body.success).toBe(true);
+      expect(updateResponse.body.data.name).toBe('Advanced Technology');
+      expect(updateResponse.body.data.description).toBe('Articles about cutting-edge technology');
+
+      // 5. Vérifier que la catégorie a été mise à jour
+      const updatedGetResponse = await request(app)
+        .get(`/api/categories/${categoryId}`)
+        .expect(200);
+
+      expect(updatedGetResponse.body.success).toBe(true);
+      expect(updatedGetResponse.body.data.name).toBe('Advanced Technology');
+    }, 30000);
+
+    it('should handle multiple categories with search and pagination', async () => {
+      // Créer plusieurs catégories
+      const categories = [
+        { name: 'Technology', description: 'Tech articles' },
+        { name: 'Science', description: 'Science articles' },
+        { name: 'Art', description: 'Art articles' },
+        { name: 'Sports', description: 'Sports articles' },
+        { name: 'Music', description: 'Music articles' }
+      ];
+
+      for (const categoryData of categories) {
+        await request(app)
+          .post('/api/categories')
+          .set('Cookie', [
+            `sessionId=${adminSession.id}`,
+            `token=${adminToken}`
+          ])
+          .send(categoryData)
+          .expect(201);
+      }
+
+      // Tester la pagination
+      const page1Response = await request(app)
+        .get('/api/categories?page=1&limit=2')
+        .expect(200);
+
+      expect(page1Response.body.success).toBe(true);
+      expect(page1Response.body.data.data).toHaveLength(2);
+      expect(page1Response.body.data.pagination.total).toBe(5);
+      expect(page1Response.body.data.pagination.totalPages).toBe(3);
+
+      // Tester la recherche
+      const searchResponse = await request(app)
+        .get('/api/categories?search=Tech')
+        .expect(200);
+
+      expect(searchResponse.body.success).toBe(true);
+      expect(searchResponse.body.data.data).toHaveLength(1);
+      expect(searchResponse.body.data.data[0].name).toBe('Technology');
+
+      // Tester le tri
+      const sortedResponse = await request(app)
+        .get('/api/categories?sortBy=name&sortOrder=ASC')
+        .expect(200);
+
+      expect(sortedResponse.body.success).toBe(true);
+      expect(sortedResponse.body.data.data[0].name).toBe('Art');
+      expect(sortedResponse.body.data.data[1].name).toBe('Music');
+    }, 30000);
+
+    it('should handle category name conflicts', async () => {
+      // Créer une première catégorie
+      const firstCategory = await request(app)
+        .post('/api/categories')
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send({
+          name: 'Technology',
+          description: 'First description'
+        })
+        .expect(201);
+
+      // Essayer de créer une catégorie avec le même nom
+      const duplicateResponse = await request(app)
+        .post('/api/categories')
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send({
+          name: 'Technology',
+          description: 'Second description'
+        })
+        .expect(409);
+
+      expect(duplicateResponse.body.success).toBe(false);
+      expect(duplicateResponse.body.message).toBe('Une catégorie avec ce nom existe déjà');
+
+      // Mettre à jour la première catégorie avec un nom qui existe déjà
+      const updateConflictResponse = await request(app)
+        .put(`/api/categories/${firstCategory.body.data.id}`)
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send({
+          name: 'Technology', // Même nom que lui-même (devrait fonctionner)
+          description: 'Updated description'
+        })
+        .expect(200);
+
+      expect(updateConflictResponse.body.success).toBe(true);
+    }, 30000);
+  });
+
+  describe('Error Handling', () => {
+    it('should handle invalid category ID', async () => {
+      const response = await request(app)
+        .get('/api/categories/invalid-id')
+        .expect(400);
+
+      expect(response.body.success).toBe(false);
+    });
+
+    it('should handle non-existent category', async () => {
+      const response = await request(app)
+        .get('/api/categories/00000000-0000-0000-0000-000000000000')
+        .expect(404);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.data).toBeNull();
+    });
+
+    it('should handle unauthorized access to protected routes', async () => {
+      // Essayer de créer une catégorie sans authentification
+      const createResponse = await request(app)
+        .post('/api/categories')
+        .send({
+          name: 'Technology',
+          description: 'Articles about technology'
+        })
+        .expect(401);
+
+      expect(createResponse.body.success).toBe(false);
+
+      // Essayer de mettre à jour une catégorie sans authentification
+      const updateResponse = await request(app)
+        .put('/api/categories/00000000-0000-0000-0000-000000000000')
+        .send({
+          name: 'Updated Technology',
+          description: 'Updated description'
+        })
+        .expect(401);
+
+      expect(updateResponse.body.success).toBe(false);
+    });
+
+    it('should handle validation errors', async () => {
+      // Créer une catégorie avec des données invalides
+      const invalidResponse = await request(app)
+        .post('/api/categories')
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send({
+          name: '', // Nom vide
+          description: '' // Description vide
+        })
+        .expect(400);
+
+      expect(invalidResponse.body.success).toBe(false);
+
+      // Mettre à jour avec des données invalides
+      const category = await Category.create({
+        name: 'Test Category',
+        description: 'Test description'
+      });
+
+      const invalidUpdateResponse = await request(app)
+        .put(`/api/categories/${category.id}`)
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send({
+          name: '', // Nom vide
+          description: '' // Description vide
+        })
+        .expect(400);
+
+      expect(invalidUpdateResponse.body.success).toBe(false);
+    });
+  });
+});

--- a/server/src/__tests__/unit/category.test.ts
+++ b/server/src/__tests__/unit/category.test.ts
@@ -1,0 +1,410 @@
+import request from 'supertest';
+import app from '../../app';
+import { Category } from '../../models/Category';
+import { User } from '../../models/User';
+import { Session } from '../../models/Session';
+import { sequelize } from '../../db/sequelize';
+import { initDatabase } from '../../db/sequelize';
+import { 
+  generateTestToken,
+  hashTestToken,
+  cleanupAuth
+} from '../fixtures/auth.fixtures';
+import { 
+  userFixtures, 
+  createUserInDb,
+  cleanupUsers
+} from '../fixtures/user.fixtures';
+
+// Fonction de nettoyage
+const cleanupCategories = async (): Promise<void> => {
+  await Category.destroy({ where: {}, force: true });
+};
+
+const cleanupUsers = async (): Promise<void> => {
+  await User.destroy({ where: {}, force: true });
+};
+
+const cleanupAuth = async (): Promise<void> => {
+  await Session.destroy({ where: {}, force: true });
+};
+
+describe('Category CRUD Operations', () => {
+  let adminUser: User;
+  let regularUser: User;
+  let adminToken: string;
+  let adminSession: Session;
+  let userToken: string;
+  let userSession: Session;
+
+  beforeAll(async () => {
+    await initDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanupCategories();
+    await cleanupUsers();
+    await cleanupAuth();
+
+    // Créer un utilisateur admin
+    adminUser = await createUserInDb(userFixtures.admin);
+    adminToken = generateTestToken(adminUser.id);
+    const adminTokenHash = await hashTestToken(adminToken);
+    adminSession = await Session.create({
+      userId: adminUser.id,
+      tokenHash: adminTokenHash,
+      ipAddress: '127.0.0.1',
+      userAgent: 'Mozilla/5.0 (Test Browser)',
+      isActive: true,
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+    });
+
+    // Créer un utilisateur régulier
+    regularUser = await createUserInDb(userFixtures.regular);
+    userToken = generateTestToken(regularUser.id);
+    const userTokenHash = await hashTestToken(userToken);
+    userSession = await Session.create({
+      userId: regularUser.id,
+      tokenHash: userTokenHash,
+      ipAddress: '127.0.0.1',
+      userAgent: 'Mozilla/5.0 (Test Browser)',
+      isActive: true,
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupCategories();
+    await cleanupUsers();
+    await cleanupAuth();
+  });
+
+  describe('GET /api/categories', () => {
+    it('should get all categories without authentication', async () => {
+      // Créer quelques catégories de test
+      await Category.create({
+        name: 'Technology',
+        description: 'Articles about technology'
+      });
+      await Category.create({
+        name: 'Science',
+        description: 'Articles about science'
+      });
+
+      const response = await request(app)
+        .get('/api/categories')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.data).toHaveLength(2);
+      expect(response.body.data.pagination.total).toBe(2);
+    });
+
+    it('should get categories with pagination', async () => {
+      // Créer plusieurs catégories
+      for (let i = 1; i <= 15; i++) {
+        await Category.create({
+          name: `Category ${i}`,
+          description: `Description for category ${i}`
+        });
+      }
+
+      const response = await request(app)
+        .get('/api/categories?page=1&limit=5')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.data).toHaveLength(5);
+      expect(response.body.data.pagination.page).toBe(1);
+      expect(response.body.data.pagination.limit).toBe(5);
+      expect(response.body.data.pagination.total).toBe(15);
+      expect(response.body.data.pagination.totalPages).toBe(3);
+    });
+
+    it('should search categories by name', async () => {
+      await Category.create({
+        name: 'Technology',
+        description: 'Articles about technology'
+      });
+      await Category.create({
+        name: 'Science',
+        description: 'Articles about science'
+      });
+
+      const response = await request(app)
+        .get('/api/categories?search=Tech')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.data).toHaveLength(1);
+      expect(response.body.data.data[0].name).toBe('Technology');
+    });
+
+    it('should sort categories', async () => {
+      await Category.create({
+        name: 'Zebra',
+        description: 'Z category'
+      });
+      await Category.create({
+        name: 'Apple',
+        description: 'A category'
+      });
+
+      const response = await request(app)
+        .get('/api/categories?sortBy=name&sortOrder=ASC')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.data[0].name).toBe('Apple');
+      expect(response.body.data.data[1].name).toBe('Zebra');
+    });
+  });
+
+  describe('GET /api/categories/:id', () => {
+    it('should get a category by ID without authentication', async () => {
+      const category = await Category.create({
+        name: 'Technology',
+        description: 'Articles about technology'
+      });
+
+      const response = await request(app)
+        .get(`/api/categories/${category.id}`)
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.id).toBe(category.id);
+      expect(response.body.data.name).toBe('Technology');
+    });
+
+    it('should return 404 for non-existent category', async () => {
+      const response = await request(app)
+        .get('/api/categories/00000000-0000-0000-0000-000000000000')
+        .expect(404);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.data).toBeNull();
+    });
+
+    it('should return 400 for invalid UUID', async () => {
+      const response = await request(app)
+        .get('/api/categories/invalid-id')
+        .expect(400);
+
+      expect(response.body.success).toBe(false);
+    });
+  });
+
+  describe('POST /api/categories', () => {
+    it('should create a category as admin', async () => {
+      const categoryData = {
+        name: 'Technology',
+        description: 'Articles about technology'
+      };
+
+      const response = await request(app)
+        .post('/api/categories')
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send(categoryData)
+        .expect(201);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.message).toBe('Catégorie créée avec succès');
+      expect(response.body.data.name).toBe('Technology');
+      expect(response.body.data.description).toBe('Articles about technology');
+    });
+
+    it('should deny access to regular user', async () => {
+      const categoryData = {
+        name: 'Technology',
+        description: 'Articles about technology'
+      };
+
+      const response = await request(app)
+        .post('/api/categories')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send(categoryData)
+        .expect(403);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Accès refusé : privilèges administrateur requis');
+    });
+
+    it('should deny access without authentication', async () => {
+      const categoryData = {
+        name: 'Technology',
+        description: 'Articles about technology'
+      };
+
+      const response = await request(app)
+        .post('/api/categories')
+        .send(categoryData)
+        .expect(401);
+
+      expect(response.body.success).toBe(false);
+    });
+
+    it('should return 409 for duplicate category name', async () => {
+      await Category.create({
+        name: 'Technology',
+        description: 'Articles about technology'
+      });
+
+      const categoryData = {
+        name: 'Technology',
+        description: 'Another description'
+      };
+
+      const response = await request(app)
+        .post('/api/categories')
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send(categoryData)
+        .expect(409);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Une catégorie avec ce nom existe déjà');
+    });
+
+    it('should validate required fields', async () => {
+      const response = await request(app)
+        .post('/api/categories')
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send({})
+        .expect(400);
+
+      expect(response.body.success).toBe(false);
+    });
+  });
+
+  describe('PUT /api/categories/:id', () => {
+    let category: Category;
+
+    beforeEach(async () => {
+      category = await Category.create({
+        name: 'Technology',
+        description: 'Articles about technology'
+      });
+    });
+
+    it('should update a category as admin', async () => {
+      const updateData = {
+        name: 'Updated Technology',
+        description: 'Updated description'
+      };
+
+      const response = await request(app)
+        .put(`/api/categories/${category.id}`)
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send(updateData)
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.message).toBe('Catégorie mise à jour avec succès');
+      expect(response.body.data.name).toBe('Updated Technology');
+      expect(response.body.data.description).toBe('Updated description');
+    });
+
+    it('should deny access to regular user', async () => {
+      const updateData = {
+        name: 'Updated Technology',
+        description: 'Updated description'
+      };
+
+      const response = await request(app)
+        .put(`/api/categories/${category.id}`)
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send(updateData)
+        .expect(403);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Accès refusé : privilèges administrateur requis');
+    });
+
+    it('should deny access without authentication', async () => {
+      const updateData = {
+        name: 'Updated Technology',
+        description: 'Updated description'
+      };
+
+      const response = await request(app)
+        .put(`/api/categories/${category.id}`)
+        .send(updateData)
+        .expect(401);
+
+      expect(response.body.success).toBe(false);
+    });
+
+    it('should return 404 for non-existent category', async () => {
+      const updateData = {
+        name: 'Updated Technology',
+        description: 'Updated description'
+      };
+
+      const response = await request(app)
+        .put('/api/categories/00000000-0000-0000-0000-000000000000')
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send(updateData)
+        .expect(404);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Catégorie non trouvée');
+    });
+
+    it('should return 409 for duplicate category name', async () => {
+      await Category.create({
+        name: 'Science',
+        description: 'Articles about science'
+      });
+
+      const updateData = {
+        name: 'Science',
+        description: 'Updated description'
+      };
+
+      const response = await request(app)
+        .put(`/api/categories/${category.id}`)
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send(updateData)
+        .expect(409);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Une catégorie avec ce nom existe déjà');
+    });
+
+    it('should validate at least one field for update', async () => {
+      const response = await request(app)
+        .put(`/api/categories/${category.id}`)
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send({})
+        .expect(400);
+
+      expect(response.body.success).toBe(false);
+    });
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -6,6 +6,7 @@ import bodyParser from 'body-parser';
 import cookieParser from 'cookie-parser';
 import userRoutes from './routes/user.routes';
 import authRoutes from './routes/auth.routes';
+import categoryRoutes from './routes/category.routes';
 import { errorHandler } from './middleware/validation';
 
 const app = express();
@@ -32,6 +33,7 @@ app.get('/', (req: Request, res: Response) => {
 
 app.use('/api/auth', authRoutes);
 app.use('/api/users', userRoutes);
+app.use('/api/categories', categoryRoutes);
 
 // Middleware de gestion d'erreurs (doit être en dernier)
 app.use(errorHandler);

--- a/server/src/controllers/category.controllers.ts
+++ b/server/src/controllers/category.controllers.ts
@@ -1,0 +1,252 @@
+import { Request, Response } from 'express';
+import { Category } from '../models/Category';
+import { Op } from 'sequelize';
+
+// Interfaces pour les requêtes
+export interface IReqCreateCategory {
+  name: string;
+  description: string;
+}
+
+export interface IReqUpdateCategory {
+  name?: string;
+  description?: string;
+}
+
+export interface IReqCategoryParams {
+  id: string;
+}
+
+export interface IReqCategoryQuery {
+  page?: number;
+  limit?: number;
+  search?: string;
+  sortBy?: 'name' | 'createdAt' | 'updatedAt';
+  sortOrder?: 'ASC' | 'DESC';
+}
+
+// Interfaces pour les réponses
+export interface IResCategory {
+  id: string;
+  name: string;
+  description: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface IResCreateCategory {
+  success: boolean;
+  message: string;
+  data: IResCategory | null;
+}
+
+export interface IResGetCategory {
+  success: boolean;
+  data: IResCategory | null;
+}
+
+export interface IResUpdateCategory {
+  success: boolean;
+  message: string;
+  data: IResCategory | null;
+}
+
+export interface IResGetCategories {
+  success: boolean;
+  data: {
+    data: IResCategory[];
+    pagination: {
+      page: number;
+      limit: number;
+      total: number;
+      totalPages: number;
+    };
+  };
+}
+
+// Créer une catégorie (admin seulement)
+export const createCategory = async (req: Request<IReqCategoryParams, IResCreateCategory, IReqCreateCategory>, res: Response<IResCreateCategory>): Promise<void> => {
+  try {
+    const { name, description } = req.body;
+
+    // Vérifier si une catégorie avec ce nom existe déjà
+    const existingCategory = await Category.findOne({ where: { name } });
+    if (existingCategory) {
+      res.status(409).json({
+        success: false,
+        message: 'Une catégorie avec ce nom existe déjà',
+        data: null
+      });
+      return;
+    }
+
+    // Créer la nouvelle catégorie
+    const category = await Category.create({
+      name,
+      description
+    });
+
+    res.status(201).json({
+      success: true,
+      message: 'Catégorie créée avec succès',
+      data: category as IResCategory
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Erreur lors de la création de la catégorie:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Erreur interne du serveur',
+      data: null
+    });
+  }
+};
+
+// Obtenir toutes les catégories (sans protection)
+export const getCategories = async (req: Request<object, IResGetCategories, object, IReqCategoryQuery>, res: Response<IResGetCategories>): Promise<void> => {
+  try {
+    const {
+      page = 1,
+      limit = 10,
+      search,
+      sortBy = 'createdAt',
+      sortOrder = 'ASC'
+    } = req.query;
+
+    // Construire les conditions de recherche
+    const whereClause: any = {};
+    if (search) {
+      whereClause[Op.or] = [
+        { name: { [Op.like]: `%${search}%` } },
+        { description: { [Op.like]: `%${search}%` } }
+      ];
+    }
+
+    // Calculer l'offset pour la pagination
+    const offset = (page - 1) * limit;
+
+    // Récupérer les catégories avec pagination
+    const { count, rows } = await Category.findAndCountAll({
+      where: whereClause,
+      order: [[sortBy, sortOrder]],
+      limit: Number(limit),
+      offset: Number(offset)
+    });
+
+    const totalPages = Math.ceil(count / limit);
+
+    res.status(200).json({
+      success: true,
+      data: {
+        data: rows as IResCategory[],
+        pagination: {
+          page: Number(page),
+          limit: Number(limit),
+          total: count,
+          totalPages
+        }
+      }
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Erreur lors de la récupération des catégories:', error);
+    res.status(500).json({
+      success: false,
+      data: {
+        data: [],
+        pagination: {
+          page: 1,
+          limit: 10,
+          total: 0,
+          totalPages: 0
+        }
+      }
+    });
+  }
+};
+
+// Obtenir une catégorie par ID (sans protection)
+export const getCategoryById = async (req: Request<IReqCategoryParams, IResGetCategory>, res: Response<IResGetCategory>): Promise<void> => {
+  try {
+    const { id } = req.params;
+
+    const category = await Category.findByPk(id);
+
+    if (!category) {
+      res.status(404).json({
+        success: false,
+        data: null
+      });
+      return;
+    }
+
+    res.status(200).json({
+      success: true,
+      data: category as IResCategory
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Erreur lors de la récupération de la catégorie:', error);
+    res.status(500).json({
+      success: false,
+      data: null
+    });
+  }
+};
+
+// Mettre à jour une catégorie (admin seulement)
+export const updateCategory = async (req: Request<IReqCategoryParams, IResUpdateCategory, IReqUpdateCategory>, res: Response<IResUpdateCategory>): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const updateData = req.body;
+
+    // Vérifier si la catégorie existe
+    const category = await Category.findByPk(id);
+    if (!category) {
+      res.status(404).json({
+        success: false,
+        message: 'Catégorie non trouvée',
+        data: null
+      });
+      return;
+    }
+
+    // Si le nom est modifié, vérifier qu'il n'existe pas déjà
+    if (updateData.name && updateData.name !== category.name) {
+      const existingCategory = await Category.findOne({
+        where: {
+          name: updateData.name,
+          id: { [Op.ne]: id }
+        }
+      });
+      if (existingCategory) {
+        res.status(409).json({
+          success: false,
+          message: 'Une catégorie avec ce nom existe déjà',
+          data: null
+        });
+        return;
+      }
+    }
+
+    // Mettre à jour la catégorie
+    await category.update(updateData);
+
+    // Récupérer la catégorie mise à jour
+    const updatedCategory = await Category.findByPk(id);
+
+    res.status(200).json({
+      success: true,
+      message: 'Catégorie mise à jour avec succès',
+      data: updatedCategory as IResCategory
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Erreur lors de la mise à jour de la catégorie:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Erreur interne du serveur',
+      data: null
+    });
+  }
+};

--- a/server/src/db/sequelize.ts
+++ b/server/src/db/sequelize.ts
@@ -2,6 +2,7 @@ import { Sequelize } from 'sequelize';
 import { env } from '../config/env';
 import { initUserModel } from '../models/User';
 import { initSessionModel } from '../models/Session';
+import { initCategoryModel } from '../models/Category';
 
 // Configuration pour les tests (mémoire) vs production (fichier)
 const isTest = env.NODE_ENV === 'test';
@@ -17,6 +18,7 @@ export async function initDatabase(): Promise<void> {
     await sequelize.authenticate();
     initUserModel(sequelize);
     initSessionModel(sequelize);
+    initCategoryModel(sequelize);
     await sequelize.sync();
     console.log("Database connected and synchronized");
   } catch (error) {

--- a/server/src/models/Category.ts
+++ b/server/src/models/Category.ts
@@ -1,0 +1,67 @@
+import { DataTypes, Model, Optional, Sequelize } from 'sequelize';
+
+// Interface pour les attributs de Category
+export interface CategoryAttributes {
+  id: string;
+  name: string;
+  description: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+// Interface pour les attributs optionnels lors de la création
+export interface CategoryCreationAttributes extends Optional<CategoryAttributes, 'id' | 'createdAt' | 'updatedAt'> {}
+
+// Classe du modèle Category
+export class Category extends Model<CategoryAttributes, CategoryCreationAttributes> implements CategoryAttributes {
+  public id!: string;
+  public name!: string;
+  public description!: string;
+  public readonly createdAt!: Date;
+  public readonly updatedAt!: Date;
+}
+
+// Fonction d'initialisation du modèle
+export function initCategoryModel(sequelize: Sequelize): void {
+  Category.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+        allowNull: false
+      },
+      name: {
+        type: DataTypes.STRING(100),
+        allowNull: false,
+        unique: true,
+        validate: {
+          notEmpty: true,
+          len: [1, 100]
+        }
+      },
+      description: {
+        type: DataTypes.TEXT,
+        allowNull: false,
+        validate: {
+          notEmpty: true
+        }
+      }
+    },
+    {
+      sequelize,
+      modelName: 'Category',
+      tableName: 'categories',
+      timestamps: true,
+      paranoid: false, // Pas de suppression douce car jamais supprimé
+      indexes: [
+        {
+          unique: true,
+          fields: ['name']
+        }
+      ]
+    }
+  );
+}
+
+export default Category;

--- a/server/src/routes/category.routes.ts
+++ b/server/src/routes/category.routes.ts
@@ -1,0 +1,55 @@
+import { Router } from 'express';
+import {
+  createCategory,
+  getCategories,
+  getCategoryById,
+  updateCategory
+} from '../controllers/category.controllers';
+import {
+  createCategorySchema,
+  updateCategorySchema,
+  getCategoriesQuerySchema,
+  categoryIdParamSchema
+} from '../schemas/category.schemas';
+import { validate, asyncHandler } from '../middleware/validation';
+import { authenticate } from '../middleware/auth';
+import { adminScope } from '../middleware/scope';
+
+const router = Router();
+
+// Routes pour les catégories
+
+// Obtenir toutes les catégories (sans protection)
+router.get(
+  '/',
+  validate(getCategoriesQuerySchema, 'query'),
+  asyncHandler(getCategories)
+);
+
+// Obtenir une catégorie par ID (sans protection)
+router.get(
+  '/:id',
+  validate(categoryIdParamSchema, 'params'),
+  asyncHandler(getCategoryById)
+);
+
+// Créer une catégorie (admin seulement)
+router.post(
+  '/',
+  authenticate,
+  adminScope,
+  validate(createCategorySchema, 'body'),
+  asyncHandler(createCategory)
+);
+
+// Mettre à jour une catégorie (admin seulement)
+router.put(
+  '/:id',
+  authenticate,
+  adminScope,
+  validate(categoryIdParamSchema, 'params'),
+  validate(updateCategorySchema, 'body'),
+  asyncHandler(updateCategory)
+);
+
+export default router;

--- a/server/src/schemas/category.schemas.ts
+++ b/server/src/schemas/category.schemas.ts
@@ -1,0 +1,98 @@
+import Joi from 'joi';
+
+// Schéma pour la création d'une catégorie
+export const createCategorySchema = Joi.object({
+  name: Joi.string()
+    .min(1)
+    .max(100)
+    .required()
+    .messages({
+      'string.empty': 'Le nom de la catégorie est requis',
+      'string.min': 'Le nom de la catégorie doit contenir au moins 1 caractère',
+      'string.max': 'Le nom de la catégorie ne peut pas dépasser 100 caractères',
+      'any.required': 'Le nom de la catégorie est requis'
+    }),
+  description: Joi.string()
+    .min(1)
+    .required()
+    .messages({
+      'string.empty': 'La description de la catégorie est requise',
+      'string.min': 'La description de la catégorie doit contenir au moins 1 caractère',
+      'any.required': 'La description de la catégorie est requise'
+    })
+});
+
+// Schéma pour la mise à jour d'une catégorie
+export const updateCategorySchema = Joi.object({
+  name: Joi.string()
+    .min(1)
+    .max(100)
+    .optional()
+    .messages({
+      'string.min': 'Le nom de la catégorie doit contenir au moins 1 caractère',
+      'string.max': 'Le nom de la catégorie ne peut pas dépasser 100 caractères'
+    }),
+  description: Joi.string()
+    .min(1)
+    .optional()
+    .messages({
+      'string.min': 'La description de la catégorie doit contenir au moins 1 caractère'
+    })
+}).min(1).messages({
+  'object.min': 'Au moins un champ doit être fourni pour la mise à jour'
+});
+
+// Schéma pour les paramètres de requête (pagination, recherche)
+export const getCategoriesQuerySchema = Joi.object({
+  page: Joi.number()
+    .integer()
+    .min(1)
+    .default(1)
+    .messages({
+      'number.base': 'La page doit être un nombre',
+      'number.integer': 'La page doit être un nombre entier',
+      'number.min': 'La page doit être supérieure ou égale à 1'
+    }),
+  limit: Joi.number()
+    .integer()
+    .min(1)
+    .max(100)
+    .default(10)
+    .messages({
+      'number.base': 'La limite doit être un nombre',
+      'number.integer': 'La limite doit être un nombre entier',
+      'number.min': 'La limite doit être supérieure ou égale à 1',
+      'number.max': 'La limite ne peut pas dépasser 100'
+    }),
+  search: Joi.string()
+    .min(1)
+    .max(100)
+    .optional()
+    .messages({
+      'string.min': 'Le terme de recherche doit contenir au moins 1 caractère',
+      'string.max': 'Le terme de recherche ne peut pas dépasser 100 caractères'
+    }),
+  sortBy: Joi.string()
+    .valid('name', 'createdAt', 'updatedAt')
+    .default('createdAt')
+    .messages({
+      'any.only': 'Le tri doit être par name, createdAt ou updatedAt'
+    }),
+  sortOrder: Joi.string()
+    .valid('ASC', 'DESC')
+    .default('ASC')
+    .messages({
+      'any.only': 'L\'ordre de tri doit être ASC ou DESC'
+    })
+});
+
+// Schéma pour les paramètres d'ID
+export const categoryIdParamSchema = Joi.object({
+  id: Joi.string()
+    .uuid()
+    .required()
+    .messages({
+      'string.guid': 'L\'ID de la catégorie doit être un UUID valide',
+      'any.required': 'L\'ID de la catégorie est requis'
+    })
+});


### PR DESCRIPTION
- Create Category model with id, name, description fields
- Add Category controller with create, read, update operations
- Implement admin-only protection for create/update operations
- Add public access for read operations (GET endpoints)
- Create comprehensive validation schemas
- Add complete test suite (25 tests) for Category functionality
- Integrate Category routes into main application
- Update database initialization to include Category model

Features:
- GET /api/categories - List all categories (public)
- GET /api/categories/:id - Get category by ID (public)
- POST /api/categories - Create category (admin only)
- PUT /api/categories/:id - Update category (admin only)
- No delete functionality as per requirements
- Search and pagination support
- Proper error handling and validation