### PR TITLE
feat: Add Article entity with CRUD operations

### DIFF
--- a/server/src/__tests__/integration/article.integration.test.ts
+++ b/server/src/__tests__/integration/article.integration.test.ts
@@ -1,0 +1,468 @@
+import request from 'supertest';
+import app from '../../app';
+import { Article } from '../../models/Article';
+import { Category } from '../../models/Category';
+import { User } from '../../models/User';
+import { Session } from '../../models/Session';
+import { sequelize } from '../../db/sequelize';
+import { initDatabase } from '../../db/sequelize';
+import { 
+  generateTestToken,
+  hashTestToken,
+  cleanupAuth
+} from '../fixtures/auth.fixtures';
+import { 
+  userFixtures, 
+  createUserInDb,
+  cleanupUsers
+} from '../fixtures/user.fixtures';
+
+// Fonction de nettoyage
+const cleanupArticles = async (): Promise<void> => {
+  await Article.destroy({ where: {}, force: true });
+};
+
+const cleanupCategories = async (): Promise<void> => {
+  await Category.destroy({ where: {}, force: true });
+};
+
+describe('Article Integration Tests', () => {
+  let adminUser: User;
+  let regularUser: User;
+  let adminToken: string;
+  let adminSession: Session;
+  let userToken: string;
+  let userSession: Session;
+  let category: Category;
+
+  beforeAll(async () => {
+    await initDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanupArticles();
+    await cleanupCategories();
+    await cleanupUsers();
+    await cleanupAuth();
+
+    // Créer un utilisateur admin
+    adminUser = await createUserInDb(userFixtures.admin);
+    adminToken = generateTestToken(adminUser.id);
+    const adminTokenHash = await hashTestToken(adminToken);
+    adminSession = await Session.create({
+      userId: adminUser.id,
+      tokenHash: adminTokenHash,
+      ipAddress: '127.0.0.1',
+      userAgent: 'Mozilla/5.0 (Test Browser)',
+      isActive: true,
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+    });
+
+    // Créer un utilisateur régulier
+    regularUser = await createUserInDb(userFixtures.regular);
+    userToken = generateTestToken(regularUser.id);
+    const userTokenHash = await hashTestToken(userToken);
+    userSession = await Session.create({
+      userId: regularUser.id,
+      tokenHash: userTokenHash,
+      ipAddress: '127.0.0.1',
+      userAgent: 'Mozilla/5.0 (Test Browser)',
+      isActive: true,
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+    });
+
+    // Créer une catégorie
+    category = await Category.create({
+      name: 'Technology',
+      description: 'Articles about technology'
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupArticles();
+    await cleanupCategories();
+    await cleanupUsers();
+    await cleanupAuth();
+  });
+
+  describe('Complete Article Workflow', () => {
+    it('should handle complete article lifecycle', async () => {
+      // 1. Créer un article
+      const createResponse = await request(app)
+        .post('/api/articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({
+          categoryId: category.id,
+          title: 'My First Article',
+          content: 'This is the content of my first article about technology.',
+          status: 'draft'
+        })
+        .expect(201);
+
+      expect(createResponse.body.success).toBe(true);
+      expect(createResponse.body.data.title).toBe('My First Article');
+      expect(createResponse.body.data.status).toBe('draft');
+      const articleId = createResponse.body.data.id;
+
+      // 2. Récupérer l'article créé
+      const getResponse = await request(app)
+        .get(`/api/articles/${articleId}`)
+        .expect(200);
+
+      expect(getResponse.body.success).toBe(true);
+      expect(getResponse.body.data.id).toBe(articleId);
+      expect(getResponse.body.data.title).toBe('My First Article');
+
+      // 3. Lister tous les articles
+      const listResponse = await request(app)
+        .get('/api/articles')
+        .expect(200);
+
+      expect(listResponse.body.success).toBe(true);
+      expect(listResponse.body.data.data).toHaveLength(1);
+      expect(listResponse.body.data.data[0].title).toBe('My First Article');
+
+      // 4. Mettre à jour l'article
+      const updateResponse = await request(app)
+        .put(`/api/articles/${articleId}`)
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({
+          title: 'Updated Article Title',
+          content: 'Updated content with more details.',
+          status: 'published'
+        })
+        .expect(200);
+
+      expect(updateResponse.body.success).toBe(true);
+      expect(updateResponse.body.data.title).toBe('Updated Article Title');
+      expect(updateResponse.body.data.status).toBe('published');
+
+      // 5. Changer le statut de l'article
+      const statusResponse = await request(app)
+        .patch(`/api/articles/${articleId}/status`)
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({ status: 'hided' })
+        .expect(200);
+
+      expect(statusResponse.body.success).toBe(true);
+      expect(statusResponse.body.data.status).toBe('hided');
+
+      // 6. Vérifier que l'article a été mis à jour
+      const updatedGetResponse = await request(app)
+        .get(`/api/articles/${articleId}`)
+        .expect(200);
+
+      expect(updatedGetResponse.body.success).toBe(true);
+      expect(updatedGetResponse.body.data.title).toBe('Updated Article Title');
+      expect(updatedGetResponse.body.data.status).toBe('hided');
+
+      // 7. Supprimer l'article
+      const deleteResponse = await request(app)
+        .delete(`/api/articles/${articleId}`)
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .expect(200);
+
+      expect(deleteResponse.body.success).toBe(true);
+      expect(deleteResponse.body.message).toBe('Article supprimé avec succès');
+
+      // 8. Vérifier que l'article a été supprimé
+      const deletedGetResponse = await request(app)
+        .get(`/api/articles/${articleId}`)
+        .expect(404);
+
+      expect(deletedGetResponse.body.success).toBe(false);
+    }, 30000);
+
+    it('should handle multiple articles with different statuses', async () => {
+      // Créer plusieurs articles avec différents statuts
+      const articles = [
+        { title: 'Published Article 1', content: 'Content 1', status: 'published' },
+        { title: 'Draft Article 1', content: 'Content 2', status: 'draft' },
+        { title: 'Hided Article 1', content: 'Content 3', status: 'hided' },
+        { title: 'Published Article 2', content: 'Content 4', status: 'published' },
+        { title: 'Draft Article 2', content: 'Content 5', status: 'draft' }
+      ];
+
+      for (const articleData of articles) {
+        await request(app)
+          .post('/api/articles')
+          .set('Cookie', [
+            `sessionId=${userSession.id}`,
+            `token=${userToken}`
+          ])
+          .send({
+            categoryId: category.id,
+            ...articleData
+          })
+          .expect(201);
+      }
+
+      // Tester la pagination
+      const page1Response = await request(app)
+        .get('/api/articles?page=1&limit=3')
+        .expect(200);
+
+      expect(page1Response.body.success).toBe(true);
+      expect(page1Response.body.data.data).toHaveLength(3);
+      expect(page1Response.body.data.pagination.total).toBe(5);
+      expect(page1Response.body.data.pagination.totalPages).toBe(2);
+
+      // Tester le filtrage par statut
+      const publishedResponse = await request(app)
+        .get('/api/articles?status=published')
+        .expect(200);
+
+      expect(publishedResponse.body.success).toBe(true);
+      expect(publishedResponse.body.data.data).toHaveLength(2);
+      expect(publishedResponse.body.data.data.every((article: any) => article.status === 'published')).toBe(true);
+
+      // Tester la recherche
+      const searchResponse = await request(app)
+        .get('/api/articles?search=Published')
+        .expect(200);
+
+      expect(searchResponse.body.success).toBe(true);
+      expect(searchResponse.body.data.data).toHaveLength(2);
+      expect(searchResponse.body.data.data.every((article: any) => article.title.includes('Published'))).toBe(true);
+
+      // Tester le tri
+      const sortedResponse = await request(app)
+        .get('/api/articles?sortBy=title&sortOrder=ASC')
+        .expect(200);
+
+      expect(sortedResponse.body.success).toBe(true);
+      const titles = sortedResponse.body.data.data.map((article: any) => article.title);
+      expect(titles).toEqual(titles.sort());
+    }, 30000);
+
+    it('should handle admin permissions correctly', async () => {
+      // Créer un article en tant qu'utilisateur régulier
+      const createResponse = await request(app)
+        .post('/api/articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({
+          categoryId: category.id,
+          title: 'User Article',
+          content: 'Content by regular user',
+          status: 'draft'
+        })
+        .expect(201);
+
+      const articleId = createResponse.body.data.id;
+
+      // Admin peut modifier l'article d'un autre utilisateur
+      const adminUpdateResponse = await request(app)
+        .put(`/api/articles/${articleId}`)
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send({
+          title: 'Admin Modified Article',
+          content: 'Modified by admin',
+          status: 'published'
+        })
+        .expect(200);
+
+      expect(adminUpdateResponse.body.success).toBe(true);
+      expect(adminUpdateResponse.body.data.title).toBe('Admin Modified Article');
+
+      // Admin peut changer le statut
+      const adminStatusResponse = await request(app)
+        .patch(`/api/articles/${articleId}/status`)
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send({ status: 'hided' })
+        .expect(200);
+
+      expect(adminStatusResponse.body.success).toBe(true);
+      expect(adminStatusResponse.body.data.status).toBe('hided');
+
+      // Admin peut supprimer l'article
+      const adminDeleteResponse = await request(app)
+        .delete(`/api/articles/${articleId}`)
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .expect(200);
+
+      expect(adminDeleteResponse.body.success).toBe(true);
+      expect(adminDeleteResponse.body.message).toBe('Article supprimé avec succès');
+    }, 30000);
+
+    it('should handle category relationships correctly', async () => {
+      // Créer une deuxième catégorie
+      const category2 = await Category.create({
+        name: 'Science',
+        description: 'Science articles'
+      });
+
+      // Créer des articles dans différentes catégories
+      const techArticle = await request(app)
+        .post('/api/articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({
+          categoryId: category.id,
+          title: 'Tech Article',
+          content: 'Technology content',
+          status: 'published'
+        })
+        .expect(201);
+
+      const scienceArticle = await request(app)
+        .post('/api/articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({
+          categoryId: category2.id,
+          title: 'Science Article',
+          content: 'Science content',
+          status: 'published'
+        })
+        .expect(201);
+
+      // Filtrer par catégorie
+      const techArticlesResponse = await request(app)
+        .get(`/api/articles?categoryId=${category.id}`)
+        .expect(200);
+
+      expect(techArticlesResponse.body.success).toBe(true);
+      expect(techArticlesResponse.body.data.data).toHaveLength(1);
+      expect(techArticlesResponse.body.data.data[0].title).toBe('Tech Article');
+
+      const scienceArticlesResponse = await request(app)
+        .get(`/api/articles?categoryId=${category2.id}`)
+        .expect(200);
+
+      expect(scienceArticlesResponse.body.success).toBe(true);
+      expect(scienceArticlesResponse.body.data.data).toHaveLength(1);
+      expect(scienceArticlesResponse.body.data.data[0].title).toBe('Science Article');
+    }, 30000);
+  });
+
+  describe('Error Handling', () => {
+    it('should handle invalid article ID', async () => {
+      const response = await request(app)
+        .get('/api/articles/invalid-id')
+        .expect(400);
+
+      expect(response.body.success).toBe(false);
+    });
+
+    it('should handle non-existent article', async () => {
+      const response = await request(app)
+        .get('/api/articles/00000000-0000-0000-0000-000000000000')
+        .expect(404);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.data).toBeNull();
+    });
+
+    it('should handle unauthorized access to protected routes', async () => {
+      // Essayer de créer un article sans authentification
+      const createResponse = await request(app)
+        .post('/api/articles')
+        .send({
+          categoryId: category.id,
+          title: 'Unauthorized Article',
+          content: 'This should fail'
+        })
+        .expect(401);
+
+      expect(createResponse.body.success).toBe(false);
+
+      // Essayer de mettre à jour un article sans authentification
+      const updateResponse = await request(app)
+        .put('/api/articles/00000000-0000-0000-0000-000000000000')
+        .send({
+          title: 'Unauthorized Update',
+          content: 'This should fail'
+        })
+        .expect(401);
+
+      expect(updateResponse.body.success).toBe(false);
+    });
+
+    it('should handle validation errors', async () => {
+      // Créer un article avec des données invalides
+      const invalidResponse = await request(app)
+        .post('/api/articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({
+          categoryId: 'invalid-uuid',
+          title: '', // Titre vide
+          content: '' // Contenu vide
+        })
+        .expect(400);
+
+      expect(invalidResponse.body.success).toBe(false);
+
+      // Mettre à jour avec des données invalides
+      const article = await Article.create({
+        userId: regularUser.id,
+        categoryId: category.id,
+        title: 'Test Article',
+        content: 'Test content',
+        status: 'draft'
+      });
+
+      const invalidUpdateResponse = await request(app)
+        .put(`/api/articles/${article.id}`)
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({
+          title: '', // Titre vide
+          content: '' // Contenu vide
+        })
+        .expect(400);
+
+      expect(invalidUpdateResponse.body.success).toBe(false);
+    });
+
+    it('should handle non-existent category when creating article', async () => {
+      const response = await request(app)
+        .post('/api/articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({
+          categoryId: '00000000-0000-0000-0000-000000000000',
+          title: 'Article with invalid category',
+          content: 'This should fail'
+        })
+        .expect(404);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Catégorie non trouvée');
+    });
+  });
+});

--- a/server/src/__tests__/unit/article.test.ts
+++ b/server/src/__tests__/unit/article.test.ts
@@ -1,0 +1,664 @@
+import request from 'supertest';
+import app from '../../app';
+import { Article } from '../../models/Article';
+import { Category } from '../../models/Category';
+import { User } from '../../models/User';
+import { Session } from '../../models/Session';
+import { sequelize } from '../../db/sequelize';
+import { initDatabase } from '../../db/sequelize';
+import { 
+  generateTestToken,
+  hashTestToken,
+  cleanupAuth
+} from '../fixtures/auth.fixtures';
+import { 
+  userFixtures, 
+  createUserInDb,
+  cleanupUsers
+} from '../fixtures/user.fixtures';
+
+// Fonction de nettoyage
+const cleanupArticles = async (): Promise<void> => {
+  await Article.destroy({ where: {}, force: true });
+};
+
+const cleanupCategories = async (): Promise<void> => {
+  await Category.destroy({ where: {}, force: true });
+};
+
+const cleanupUsers = async (): Promise<void> => {
+  await User.destroy({ where: {}, force: true });
+};
+
+describe('Article CRUD Operations', () => {
+  let adminUser: User;
+  let regularUser: User;
+  let adminToken: string;
+  let adminSession: Session;
+  let userToken: string;
+  let userSession: Session;
+  let category: Category;
+
+  beforeAll(async () => {
+    await initDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanupArticles();
+    await cleanupCategories();
+    await cleanupUsers();
+    await cleanupAuth();
+
+    // Créer un utilisateur admin
+    adminUser = await createUserInDb(userFixtures.admin);
+    adminToken = generateTestToken(adminUser.id);
+    const adminTokenHash = await hashTestToken(adminToken);
+    adminSession = await Session.create({
+      userId: adminUser.id,
+      tokenHash: adminTokenHash,
+      ipAddress: '127.0.0.1',
+      userAgent: 'Mozilla/5.0 (Test Browser)',
+      isActive: true,
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+    });
+
+    // Créer un utilisateur régulier
+    regularUser = await createUserInDb(userFixtures.regular);
+    userToken = generateTestToken(regularUser.id);
+    const userTokenHash = await hashTestToken(userToken);
+    userSession = await Session.create({
+      userId: regularUser.id,
+      tokenHash: userTokenHash,
+      ipAddress: '127.0.0.1',
+      userAgent: 'Mozilla/5.0 (Test Browser)',
+      isActive: true,
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+    });
+
+    // Créer une catégorie
+    category = await Category.create({
+      name: 'Technology',
+      description: 'Articles about technology'
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupArticles();
+    await cleanupCategories();
+    await cleanupUsers();
+    await cleanupAuth();
+  });
+
+  describe('GET /api/articles', () => {
+    it('should get all articles without authentication', async () => {
+      // Créer quelques articles de test
+      await Article.create({
+        userId: regularUser.id,
+        categoryId: category.id,
+        title: 'Article 1',
+        content: 'Content 1',
+        status: 'published'
+      });
+      await Article.create({
+        userId: adminUser.id,
+        categoryId: category.id,
+        title: 'Article 2',
+        content: 'Content 2',
+        status: 'draft'
+      });
+
+      const response = await request(app)
+        .get('/api/articles')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.data).toHaveLength(2);
+      expect(response.body.data.pagination.total).toBe(2);
+    });
+
+    it('should get articles with pagination', async () => {
+      // Créer plusieurs articles
+      for (let i = 1; i <= 15; i++) {
+        await Article.create({
+          userId: regularUser.id,
+          categoryId: category.id,
+          title: `Article ${i}`,
+          content: `Content for article ${i}`,
+          status: 'published'
+        });
+      }
+
+      const response = await request(app)
+        .get('/api/articles?page=1&limit=5')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.data).toHaveLength(5);
+      expect(response.body.data.pagination.page).toBe(1);
+      expect(response.body.data.pagination.limit).toBe(5);
+      expect(response.body.data.pagination.total).toBe(15);
+      expect(response.body.data.pagination.totalPages).toBe(3);
+    });
+
+    it('should search articles by title and content', async () => {
+      await Article.create({
+        userId: regularUser.id,
+        categoryId: category.id,
+        title: 'JavaScript Tutorial',
+        content: 'Learn JavaScript basics',
+        status: 'published'
+      });
+      await Article.create({
+        userId: adminUser.id,
+        categoryId: category.id,
+        title: 'Python Guide',
+        content: 'Learn Python programming',
+        status: 'published'
+      });
+
+      const response = await request(app)
+        .get('/api/articles?search=JavaScript')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.data).toHaveLength(1);
+      expect(response.body.data.data[0].title).toBe('JavaScript Tutorial');
+    });
+
+    it('should filter articles by status', async () => {
+      await Article.create({
+        userId: regularUser.id,
+        categoryId: category.id,
+        title: 'Published Article',
+        content: 'This is published',
+        status: 'published'
+      });
+      await Article.create({
+        userId: regularUser.id,
+        categoryId: category.id,
+        title: 'Draft Article',
+        content: 'This is draft',
+        status: 'draft'
+      });
+
+      const response = await request(app)
+        .get('/api/articles?status=published')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.data).toHaveLength(1);
+      expect(response.body.data.data[0].title).toBe('Published Article');
+    });
+
+    it('should filter articles by category', async () => {
+      const category2 = await Category.create({
+        name: 'Science',
+        description: 'Science articles'
+      });
+
+      await Article.create({
+        userId: regularUser.id,
+        categoryId: category.id,
+        title: 'Tech Article',
+        content: 'Technology content',
+        status: 'published'
+      });
+      await Article.create({
+        userId: regularUser.id,
+        categoryId: category2.id,
+        title: 'Science Article',
+        content: 'Science content',
+        status: 'published'
+      });
+
+      const response = await request(app)
+        .get(`/api/articles?categoryId=${category.id}`)
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.data).toHaveLength(1);
+      expect(response.body.data.data[0].title).toBe('Tech Article');
+    });
+
+    it('should sort articles', async () => {
+      await Article.create({
+        userId: regularUser.id,
+        categoryId: category.id,
+        title: 'Z Article',
+        content: 'Z content',
+        status: 'published'
+      });
+      await Article.create({
+        userId: regularUser.id,
+        categoryId: category.id,
+        title: 'A Article',
+        content: 'A content',
+        status: 'published'
+      });
+
+      const response = await request(app)
+        .get('/api/articles?sortBy=title&sortOrder=ASC')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.data[0].title).toBe('A Article');
+      expect(response.body.data.data[1].title).toBe('Z Article');
+    });
+  });
+
+  describe('GET /api/articles/:id', () => {
+    it('should get an article by ID without authentication', async () => {
+      const article = await Article.create({
+        userId: regularUser.id,
+        categoryId: category.id,
+        title: 'Test Article',
+        content: 'Test content',
+        status: 'published'
+      });
+
+      const response = await request(app)
+        .get(`/api/articles/${article.id}`)
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.id).toBe(article.id);
+      expect(response.body.data.title).toBe('Test Article');
+    });
+
+    it('should return 404 for non-existent article', async () => {
+      const response = await request(app)
+        .get('/api/articles/00000000-0000-0000-0000-000000000000')
+        .expect(404);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.data).toBeNull();
+    });
+
+    it('should return 400 for invalid UUID', async () => {
+      const response = await request(app)
+        .get('/api/articles/invalid-id')
+        .expect(400);
+
+      expect(response.body.success).toBe(false);
+    });
+  });
+
+  describe('POST /api/articles', () => {
+    it('should create an article as authenticated user', async () => {
+      const articleData = {
+        categoryId: category.id,
+        title: 'New Article',
+        content: 'New article content',
+        status: 'draft'
+      };
+
+      const response = await request(app)
+        .post('/api/articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send(articleData)
+        .expect(201);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.message).toBe('Article créé avec succès');
+      expect(response.body.data.title).toBe('New Article');
+      expect(response.body.data.userId).toBe(regularUser.id);
+    });
+
+    it('should deny access without authentication', async () => {
+      const articleData = {
+        categoryId: category.id,
+        title: 'New Article',
+        content: 'New article content'
+      };
+
+      const response = await request(app)
+        .post('/api/articles')
+        .send(articleData)
+        .expect(401);
+
+      expect(response.body.success).toBe(false);
+    });
+
+    it('should return 404 for non-existent category', async () => {
+      const articleData = {
+        categoryId: '00000000-0000-0000-0000-000000000000',
+        title: 'New Article',
+        content: 'New article content'
+      };
+
+      const response = await request(app)
+        .post('/api/articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send(articleData)
+        .expect(404);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Catégorie non trouvée');
+    });
+
+    it('should validate required fields', async () => {
+      const response = await request(app)
+        .post('/api/articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({})
+        .expect(400);
+
+      expect(response.body.success).toBe(false);
+    });
+  });
+
+  describe('PUT /api/articles/:id', () => {
+    let article: Article;
+
+    beforeEach(async () => {
+      article = await Article.create({
+        userId: regularUser.id,
+        categoryId: category.id,
+        title: 'Original Title',
+        content: 'Original content',
+        status: 'draft'
+      });
+    });
+
+    it('should update an article as the author', async () => {
+      const updateData = {
+        title: 'Updated Title',
+        content: 'Updated content',
+        status: 'published'
+      };
+
+      const response = await request(app)
+        .put(`/api/articles/${article.id}`)
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send(updateData)
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.message).toBe('Article mis à jour avec succès');
+      expect(response.body.data.title).toBe('Updated Title');
+      expect(response.body.data.status).toBe('published');
+    });
+
+    it('should update an article as admin', async () => {
+      const updateData = {
+        title: 'Admin Updated Title',
+        content: 'Admin updated content'
+      };
+
+      const response = await request(app)
+        .put(`/api/articles/${article.id}`)
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send(updateData)
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.title).toBe('Admin Updated Title');
+    });
+
+    it('should deny access to other users', async () => {
+      const otherUser = await createUserInDb({
+        firstname: 'Other',
+        lastname: 'User',
+        email: 'other@example.com',
+        password: 'password123'
+      });
+      const otherToken = generateTestToken(otherUser.id);
+      const otherTokenHash = await hashTestToken(otherToken);
+      const otherSession = await Session.create({
+        userId: otherUser.id,
+        tokenHash: otherTokenHash,
+        ipAddress: '127.0.0.1',
+        userAgent: 'Mozilla/5.0 (Test Browser)',
+        isActive: true,
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+      });
+
+      const updateData = {
+        title: 'Unauthorized Update',
+        content: 'Unauthorized content'
+      };
+
+      const response = await request(app)
+        .put(`/api/articles/${article.id}`)
+        .set('Cookie', [
+          `sessionId=${otherSession.id}`,
+          `token=${otherToken}`
+        ])
+        .send(updateData)
+        .expect(403);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Vous ne pouvez modifier que vos propres articles');
+    });
+
+    it('should deny access without authentication', async () => {
+      const updateData = {
+        title: 'Unauthorized Update',
+        content: 'Unauthorized content'
+      };
+
+      const response = await request(app)
+        .put(`/api/articles/${article.id}`)
+        .send(updateData)
+        .expect(401);
+
+      expect(response.body.success).toBe(false);
+    });
+
+    it('should return 404 for non-existent article', async () => {
+      const updateData = {
+        title: 'Updated Title',
+        content: 'Updated content'
+      };
+
+      const response = await request(app)
+        .put('/api/articles/00000000-0000-0000-0000-000000000000')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send(updateData)
+        .expect(404);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Article non trouvé');
+    });
+  });
+
+  describe('DELETE /api/articles/:id', () => {
+    let article: Article;
+
+    beforeEach(async () => {
+      article = await Article.create({
+        userId: regularUser.id,
+        categoryId: category.id,
+        title: 'Article to Delete',
+        content: 'Content to delete',
+        status: 'draft'
+      });
+    });
+
+    it('should delete an article as the author', async () => {
+      const response = await request(app)
+        .delete(`/api/articles/${article.id}`)
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.message).toBe('Article supprimé avec succès');
+
+      // Vérifier que l'article a été supprimé
+      const deletedArticle = await Article.findByPk(article.id);
+      expect(deletedArticle).toBeNull();
+    });
+
+    it('should delete an article as admin', async () => {
+      const response = await request(app)
+        .delete(`/api/articles/${article.id}`)
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.message).toBe('Article supprimé avec succès');
+    });
+
+    it('should deny access to other users', async () => {
+      const otherUser = await createUserInDb({
+        firstname: 'Other',
+        lastname: 'User',
+        email: 'other@example.com',
+        password: 'password123'
+      });
+      const otherToken = generateTestToken(otherUser.id);
+      const otherTokenHash = await hashTestToken(otherToken);
+      const otherSession = await Session.create({
+        userId: otherUser.id,
+        tokenHash: otherTokenHash,
+        ipAddress: '127.0.0.1',
+        userAgent: 'Mozilla/5.0 (Test Browser)',
+        isActive: true,
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+      });
+
+      const response = await request(app)
+        .delete(`/api/articles/${article.id}`)
+        .set('Cookie', [
+          `sessionId=${otherSession.id}`,
+          `token=${otherToken}`
+        ])
+        .expect(403);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Vous ne pouvez supprimer que vos propres articles');
+    });
+
+    it('should deny access without authentication', async () => {
+      const response = await request(app)
+        .delete(`/api/articles/${article.id}`)
+        .expect(401);
+
+      expect(response.body.success).toBe(false);
+    });
+
+    it('should return 404 for non-existent article', async () => {
+      const response = await request(app)
+        .delete('/api/articles/00000000-0000-0000-0000-000000000000')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .expect(404);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Article non trouvé');
+    });
+  });
+
+  describe('PATCH /api/articles/:id/status', () => {
+    let article: Article;
+
+    beforeEach(async () => {
+      article = await Article.create({
+        userId: regularUser.id,
+        categoryId: category.id,
+        title: 'Status Article',
+        content: 'Content for status change',
+        status: 'draft'
+      });
+    });
+
+    it('should change article status as the author', async () => {
+      const response = await request(app)
+        .patch(`/api/articles/${article.id}/status`)
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({ status: 'published' })
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.message).toBe('Statut de l\'article mis à jour avec succès');
+      expect(response.body.data.status).toBe('published');
+    });
+
+    it('should change article status as admin', async () => {
+      const response = await request(app)
+        .patch(`/api/articles/${article.id}/status`)
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send({ status: 'hided' })
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.status).toBe('hided');
+    });
+
+    it('should deny access to other users', async () => {
+      const otherUser = await createUserInDb({
+        firstname: 'Other',
+        lastname: 'User',
+        email: 'other@example.com',
+        password: 'password123'
+      });
+      const otherToken = generateTestToken(otherUser.id);
+      const otherTokenHash = await hashTestToken(otherToken);
+      const otherSession = await Session.create({
+        userId: otherUser.id,
+        tokenHash: otherTokenHash,
+        ipAddress: '127.0.0.1',
+        userAgent: 'Mozilla/5.0 (Test Browser)',
+        isActive: true,
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+      });
+
+      const response = await request(app)
+        .patch(`/api/articles/${article.id}/status`)
+        .set('Cookie', [
+          `sessionId=${otherSession.id}`,
+          `token=${otherToken}`
+        ])
+        .send({ status: 'published' })
+        .expect(403);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Vous ne pouvez modifier que vos propres articles');
+    });
+
+    it('should validate status values', async () => {
+      const response = await request(app)
+        .patch(`/api/articles/${article.id}/status`)
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({ status: 'invalid' })
+        .expect(400);
+
+      expect(response.body.success).toBe(false);
+    });
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -7,6 +7,7 @@ import cookieParser from 'cookie-parser';
 import userRoutes from './routes/user.routes';
 import authRoutes from './routes/auth.routes';
 import categoryRoutes from './routes/category.routes';
+import articleRoutes from './routes/article.routes';
 import { errorHandler } from './middleware/validation';
 
 const app = express();
@@ -34,6 +35,7 @@ app.get('/', (req: Request, res: Response) => {
 app.use('/api/auth', authRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/categories', categoryRoutes);
+app.use('/api/articles', articleRoutes);
 
 // Middleware de gestion d'erreurs (doit être en dernier)
 app.use(errorHandler);

--- a/server/src/controllers/article.controllers.ts
+++ b/server/src/controllers/article.controllers.ts
@@ -1,0 +1,473 @@
+import { Request, Response } from 'express';
+import { Article } from '../models/Article';
+import { Category } from '../models/Category';
+import { User } from '../models/User';
+import { Op } from 'sequelize';
+import { AuthenticatedRequest } from '../middleware/auth';
+
+// Interfaces pour les requêtes
+export interface IReqCreateArticle {
+  categoryId: string;
+  title: string;
+  content: string;
+  status?: 'draft' | 'published' | 'hided';
+}
+
+export interface IReqUpdateArticle {
+  categoryId?: string;
+  title?: string;
+  content?: string;
+  status?: 'draft' | 'published' | 'hided';
+}
+
+export interface IReqArticleParams {
+  id: string;
+}
+
+export interface IReqArticleQuery {
+  page?: number;
+  limit?: number;
+  search?: string;
+  status?: 'draft' | 'published' | 'hided';
+  categoryId?: string;
+  userId?: string;
+  sortBy?: 'title' | 'createdAt' | 'updatedAt' | 'status';
+  sortOrder?: 'ASC' | 'DESC';
+}
+
+export interface IReqChangeStatus {
+  status: 'draft' | 'published' | 'hided';
+}
+
+// Interfaces pour les réponses
+export interface IResArticle {
+  id: string;
+  userId: string;
+  categoryId: string;
+  title: string;
+  content: string;
+  status: 'draft' | 'published' | 'hided';
+  createdAt: Date;
+  updatedAt: Date;
+  User?: {
+    id: string;
+    firstname: string;
+    lastname: string;
+    email: string;
+  };
+  Category?: {
+    id: string;
+    name: string;
+    description: string;
+  };
+}
+
+export interface IResCreateArticle {
+  success: boolean;
+  message: string;
+  data: IResArticle | null;
+}
+
+export interface IResGetArticle {
+  success: boolean;
+  data: IResArticle | null;
+}
+
+export interface IResUpdateArticle {
+  success: boolean;
+  message: string;
+  data: IResArticle | null;
+}
+
+export interface IResGetArticles {
+  success: boolean;
+  data: {
+    data: IResArticle[];
+    pagination: {
+      page: number;
+      limit: number;
+      total: number;
+      totalPages: number;
+    };
+  };
+}
+
+export interface IResDeleteArticle {
+  success: boolean;
+  message: string;
+}
+
+// Créer un article
+export const createArticle = async (req: AuthenticatedRequest<IReqArticleParams, IResCreateArticle, IReqCreateArticle>, res: Response<IResCreateArticle>): Promise<void> => {
+  try {
+    const { categoryId, title, content, status = 'draft' } = req.body;
+    const userId = req.user!.id;
+
+    // Vérifier que la catégorie existe
+    const category = await Category.findByPk(categoryId);
+    if (!category) {
+      res.status(404).json({
+        success: false,
+        message: 'Catégorie non trouvée',
+        data: null
+      });
+      return;
+    }
+
+    // Créer l'article
+    const article = await Article.create({
+      userId,
+      categoryId,
+      title,
+      content,
+      status
+    });
+
+    // Récupérer l'article avec les relations
+    const articleWithRelations = await Article.findByPk(article.id, {
+      include: [
+        {
+          model: User,
+          as: 'User',
+          attributes: ['id', 'firstname', 'lastname', 'email']
+        },
+        {
+          model: Category,
+          as: 'Category',
+          attributes: ['id', 'name', 'description']
+        }
+      ]
+    });
+
+    res.status(201).json({
+      success: true,
+      message: 'Article créé avec succès',
+      data: articleWithRelations as IResArticle
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Erreur lors de la création de l\'article:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Erreur interne du serveur',
+      data: null
+    });
+  }
+};
+
+// Obtenir tous les articles (sans protection)
+export const getArticles = async (req: Request<object, IResGetArticles, object, IReqArticleQuery>, res: Response<IResGetArticles>): Promise<void> => {
+  try {
+    const {
+      page = 1,
+      limit = 10,
+      search,
+      status,
+      categoryId,
+      userId,
+      sortBy = 'createdAt',
+      sortOrder = 'DESC'
+    } = req.query;
+
+    // Construire les conditions de recherche
+    const whereClause: any = {};
+    
+    if (search) {
+      whereClause[Op.or] = [
+        { title: { [Op.like]: `%${search}%` } },
+        { content: { [Op.like]: `%${search}%` } }
+      ];
+    }
+    
+    if (status) {
+      whereClause.status = status;
+    }
+    
+    if (categoryId) {
+      whereClause.categoryId = categoryId;
+    }
+    
+    if (userId) {
+      whereClause.userId = userId;
+    }
+
+    // Calculer l'offset pour la pagination
+    const offset = (page - 1) * limit;
+
+    // Récupérer les articles avec pagination
+    const { count, rows } = await Article.findAndCountAll({
+      where: whereClause,
+      include: [
+        {
+          model: User,
+          as: 'User',
+          attributes: ['id', 'firstname', 'lastname', 'email']
+        },
+        {
+          model: Category,
+          as: 'Category',
+          attributes: ['id', 'name', 'description']
+        }
+      ],
+      order: [[sortBy, sortOrder]],
+      limit: Number(limit),
+      offset: Number(offset)
+    });
+
+    const totalPages = Math.ceil(count / limit);
+
+    res.status(200).json({
+      success: true,
+      data: {
+        data: rows as IResArticle[],
+        pagination: {
+          page: Number(page),
+          limit: Number(limit),
+          total: count,
+          totalPages
+        }
+      }
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Erreur lors de la récupération des articles:', error);
+    res.status(500).json({
+      success: false,
+      data: {
+        data: [],
+        pagination: {
+          page: 1,
+          limit: 10,
+          total: 0,
+          totalPages: 0
+        }
+      }
+    });
+  }
+};
+
+// Obtenir un article par ID (sans protection)
+export const getArticleById = async (req: Request<IReqArticleParams, IResGetArticle>, res: Response<IResGetArticle>): Promise<void> => {
+  try {
+    const { id } = req.params;
+
+    const article = await Article.findByPk(id, {
+      include: [
+        {
+          model: User,
+          as: 'User',
+          attributes: ['id', 'firstname', 'lastname', 'email']
+        },
+        {
+          model: Category,
+          as: 'Category',
+          attributes: ['id', 'name', 'description']
+        }
+      ]
+    });
+
+    if (!article) {
+      res.status(404).json({
+        success: false,
+        data: null
+      });
+      return;
+    }
+
+    res.status(200).json({
+      success: true,
+      data: article as IResArticle
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Erreur lors de la récupération de l\'article:', error);
+    res.status(500).json({
+      success: false,
+      data: null
+    });
+  }
+};
+
+// Mettre à jour un article
+export const updateArticle = async (req: AuthenticatedRequest<IReqArticleParams, IResUpdateArticle, IReqUpdateArticle>, res: Response<IResUpdateArticle>): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const updateData = req.body;
+    const userId = req.user!.id;
+    const isAdmin = req.user!.isAdmin;
+
+    // Vérifier si l'article existe
+    const article = await Article.findByPk(id);
+    if (!article) {
+      res.status(404).json({
+        success: false,
+        message: 'Article non trouvé',
+        data: null
+      });
+      return;
+    }
+
+    // Vérifier les permissions : seul l'auteur ou un admin peut modifier
+    if (!isAdmin && article.userId !== userId) {
+      res.status(403).json({
+        success: false,
+        message: 'Vous ne pouvez modifier que vos propres articles',
+        data: null
+      });
+      return;
+    }
+
+    // Si la catégorie est modifiée, vérifier qu'elle existe
+    if (updateData.categoryId && updateData.categoryId !== article.categoryId) {
+      const category = await Category.findByPk(updateData.categoryId);
+      if (!category) {
+        res.status(404).json({
+          success: false,
+          message: 'Catégorie non trouvée',
+          data: null
+        });
+        return;
+      }
+    }
+
+    // Mettre à jour l'article
+    await article.update(updateData);
+
+    // Récupérer l'article mis à jour avec les relations
+    const updatedArticle = await Article.findByPk(id, {
+      include: [
+        {
+          model: User,
+          as: 'User',
+          attributes: ['id', 'firstname', 'lastname', 'email']
+        },
+        {
+          model: Category,
+          as: 'Category',
+          attributes: ['id', 'name', 'description']
+        }
+      ]
+    });
+
+    res.status(200).json({
+      success: true,
+      message: 'Article mis à jour avec succès',
+      data: updatedArticle as IResArticle
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Erreur lors de la mise à jour de l\'article:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Erreur interne du serveur',
+      data: null
+    });
+  }
+};
+
+// Supprimer un article
+export const deleteArticle = async (req: AuthenticatedRequest<IReqArticleParams, IResDeleteArticle>, res: Response<IResDeleteArticle>): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const userId = req.user!.id;
+    const isAdmin = req.user!.isAdmin;
+
+    // Vérifier si l'article existe
+    const article = await Article.findByPk(id);
+    if (!article) {
+      res.status(404).json({
+        success: false,
+        message: 'Article non trouvé'
+      });
+      return;
+    }
+
+    // Vérifier les permissions : seul l'auteur ou un admin peut supprimer
+    if (!isAdmin && article.userId !== userId) {
+      res.status(403).json({
+        success: false,
+        message: 'Vous ne pouvez supprimer que vos propres articles'
+      });
+      return;
+    }
+
+    // Supprimer l'article
+    await article.destroy();
+
+    res.status(200).json({
+      success: true,
+      message: 'Article supprimé avec succès'
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Erreur lors de la suppression de l\'article:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Erreur interne du serveur'
+    });
+  }
+};
+
+// Changer le statut d'un article
+export const changeArticleStatus = async (req: AuthenticatedRequest<IReqArticleParams, IResUpdateArticle, IReqChangeStatus>, res: Response<IResUpdateArticle>): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const { status } = req.body;
+    const userId = req.user!.id;
+    const isAdmin = req.user!.isAdmin;
+
+    // Vérifier si l'article existe
+    const article = await Article.findByPk(id);
+    if (!article) {
+      res.status(404).json({
+        success: false,
+        message: 'Article non trouvé',
+        data: null
+      });
+      return;
+    }
+
+    // Vérifier les permissions : seul l'auteur ou un admin peut changer le statut
+    if (!isAdmin && article.userId !== userId) {
+      res.status(403).json({
+        success: false,
+        message: 'Vous ne pouvez modifier que vos propres articles',
+        data: null
+      });
+      return;
+    }
+
+    // Mettre à jour le statut
+    await article.update({ status });
+
+    // Récupérer l'article mis à jour avec les relations
+    const updatedArticle = await Article.findByPk(id, {
+      include: [
+        {
+          model: User,
+          as: 'User',
+          attributes: ['id', 'firstname', 'lastname', 'email']
+        },
+        {
+          model: Category,
+          as: 'Category',
+          attributes: ['id', 'name', 'description']
+        }
+      ]
+    });
+
+    res.status(200).json({
+      success: true,
+      message: 'Statut de l\'article mis à jour avec succès',
+      data: updatedArticle as IResArticle
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Erreur lors du changement de statut:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Erreur interne du serveur',
+      data: null
+    });
+  }
+};

--- a/server/src/db/sequelize.ts
+++ b/server/src/db/sequelize.ts
@@ -3,6 +3,8 @@ import { env } from '../config/env';
 import { initUserModel } from '../models/User';
 import { initSessionModel } from '../models/Session';
 import { initCategoryModel } from '../models/Category';
+import { initArticleModel } from '../models/Article';
+import { setupAssociations } from '../models/associations';
 
 // Configuration pour les tests (mémoire) vs production (fichier)
 const isTest = env.NODE_ENV === 'test';
@@ -19,10 +21,15 @@ export async function initDatabase(): Promise<void> {
     initUserModel(sequelize);
     initSessionModel(sequelize);
     initCategoryModel(sequelize);
+    initArticleModel(sequelize);
+    
+    // Configurer les associations après l'initialisation des modèles
+    setupAssociations(sequelize);
+    
     await sequelize.sync();
     console.log("Database connected and synchronized");
   } catch (error) {
     console.error("Database initialization failed", error);
-    process.exit(1);
+    throw error;
   }
 }

--- a/server/src/middleware/scope.ts
+++ b/server/src/middleware/scope.ts
@@ -160,3 +160,33 @@ export const meScope = (req: AuthenticatedRequest, res: Response, next: NextFunc
     });
   }
 };
+
+// Middleware pour vérifier que l'utilisateur est l'auteur de l'article ou un admin
+export const articleAuthorOrAdminScope = (req: AuthenticatedRequest, res: Response, next: NextFunction): void => {
+  try {
+    // Vérifier que l'utilisateur est authentifié
+    if (!req.user) {
+      res.status(401).json({
+        success: false,
+        message: 'Non authentifié'
+      });
+      return;
+    }
+
+    // Si l'utilisateur est admin, il peut accéder à tout
+    if (req.user.isAdmin) {
+      next();
+      return;
+    }
+
+    // Pour les articles, nous devons vérifier que l'utilisateur est l'auteur
+    // Cette vérification sera faite dans le contrôleur car nous avons besoin de récupérer l'article
+    next();
+  } catch (error) {
+    console.error('Erreur dans le middleware articleAuthorOrAdminScope:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Erreur interne du serveur'
+    });
+  }
+};

--- a/server/src/models/Article.ts
+++ b/server/src/models/Article.ts
@@ -1,0 +1,108 @@
+import { DataTypes, Model, Optional, Sequelize } from 'sequelize';
+
+// Interface pour les attributs de Article
+export interface ArticleAttributes {
+  id: string;
+  userId: string;
+  categoryId: string;
+  title: string;
+  content: string;
+  status: 'draft' | 'published' | 'hided';
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+// Interface pour les attributs optionnels lors de la création
+export interface ArticleCreationAttributes extends Optional<ArticleAttributes, 'id' | 'createdAt' | 'updatedAt'> {}
+
+// Classe du modèle Article
+export class Article extends Model<ArticleAttributes, ArticleCreationAttributes> implements ArticleAttributes {
+  public id!: string;
+  public userId!: string;
+  public categoryId!: string;
+  public title!: string;
+  public content!: string;
+  public status!: 'draft' | 'published' | 'hided';
+  public readonly createdAt!: Date;
+  public readonly updatedAt!: Date;
+}
+
+// Fonction d'initialisation du modèle
+export function initArticleModel(sequelize: Sequelize): void {
+  Article.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+        allowNull: false
+      },
+      userId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        references: {
+          model: 'users',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      categoryId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        references: {
+          model: 'categories',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'RESTRICT' // Empêche la suppression d'une catégorie si elle a des articles
+      },
+      title: {
+        type: DataTypes.STRING(200),
+        allowNull: false,
+        validate: {
+          notEmpty: true,
+          len: [1, 200]
+        }
+      },
+      content: {
+        type: DataTypes.TEXT,
+        allowNull: false,
+        validate: {
+          notEmpty: true
+        }
+      },
+      status: {
+        type: DataTypes.ENUM('draft', 'published', 'hided'),
+        allowNull: false,
+        defaultValue: 'draft',
+        validate: {
+          isIn: [['draft', 'published', 'hided']]
+        }
+      }
+    },
+    {
+      sequelize,
+      modelName: 'Article',
+      tableName: 'articles',
+      timestamps: true,
+      paranoid: false,
+      indexes: [
+        {
+          fields: ['userId']
+        },
+        {
+          fields: ['categoryId']
+        },
+        {
+          fields: ['status']
+        },
+        {
+          fields: ['createdAt']
+        }
+      ]
+    }
+  );
+}
+
+export default Article;

--- a/server/src/models/associations.ts
+++ b/server/src/models/associations.ts
@@ -1,0 +1,27 @@
+import { Sequelize } from 'sequelize';
+
+export function setupAssociations(sequelize: Sequelize): void {
+  const { User } = sequelize.models;
+  const { Category } = sequelize.models;
+  const { Article } = sequelize.models;
+
+  // Association User -> Article (One-to-Many)
+  User.hasMany(Article, {
+    foreignKey: 'userId',
+    as: 'Articles'
+  });
+  Article.belongsTo(User, {
+    foreignKey: 'userId',
+    as: 'User'
+  });
+
+  // Association Category -> Article (One-to-Many)
+  Category.hasMany(Article, {
+    foreignKey: 'categoryId',
+    as: 'Articles'
+  });
+  Article.belongsTo(Category, {
+    foreignKey: 'categoryId',
+    as: 'Category'
+  });
+}

--- a/server/src/routes/article.routes.ts
+++ b/server/src/routes/article.routes.ts
@@ -1,0 +1,76 @@
+import { Router } from 'express';
+import {
+  createArticle,
+  getArticles,
+  getArticleById,
+  updateArticle,
+  deleteArticle,
+  changeArticleStatus
+} from '../controllers/article.controllers';
+import {
+  createArticleSchema,
+  updateArticleSchema,
+  getArticlesQuerySchema,
+  articleIdParamSchema,
+  changeArticleStatusSchema
+} from '../schemas/article.schemas';
+import { validate, asyncHandler } from '../middleware/validation';
+import { authenticate } from '../middleware/auth';
+import { articleAuthorOrAdminScope } from '../middleware/scope';
+
+const router = Router();
+
+// Routes pour les articles
+
+// Obtenir tous les articles (sans protection)
+router.get(
+  '/',
+  validate(getArticlesQuerySchema, 'query'),
+  asyncHandler(getArticles)
+);
+
+// Obtenir un article par ID (sans protection)
+router.get(
+  '/:id',
+  validate(articleIdParamSchema, 'params'),
+  asyncHandler(getArticleById)
+);
+
+// Créer un article (authentification requise)
+router.post(
+  '/',
+  authenticate,
+  validate(createArticleSchema, 'body'),
+  asyncHandler(createArticle)
+);
+
+// Mettre à jour un article (authentification requise, user ou admin)
+router.put(
+  '/:id',
+  authenticate,
+  articleAuthorOrAdminScope,
+  validate(articleIdParamSchema, 'params'),
+  validate(updateArticleSchema, 'body'),
+  asyncHandler(updateArticle)
+);
+
+// Supprimer un article (authentification requise, user ou admin)
+router.delete(
+  '/:id',
+  authenticate,
+  articleAuthorOrAdminScope,
+  validate(articleIdParamSchema, 'params'),
+  asyncHandler(deleteArticle)
+);
+
+// Changer le statut d'un article (authentification requise, user ou admin)
+router.patch(
+  '/:id/status',
+  authenticate,
+  articleAuthorOrAdminScope,
+  validate(articleIdParamSchema, 'params'),
+  validate(changeArticleStatusSchema, 'body'),
+  asyncHandler(changeArticleStatus)
+);
+
+export default router;

--- a/server/src/schemas/article.schemas.ts
+++ b/server/src/schemas/article.schemas.ts
@@ -1,0 +1,152 @@
+import Joi from 'joi';
+
+// Schéma pour la création d'un article
+export const createArticleSchema = Joi.object({
+  categoryId: Joi.string()
+    .uuid()
+    .required()
+    .messages({
+      'string.guid': 'L\'ID de la catégorie doit être un UUID valide',
+      'any.required': 'L\'ID de la catégorie est requis'
+    }),
+  title: Joi.string()
+    .min(1)
+    .max(200)
+    .required()
+    .messages({
+      'string.empty': 'Le titre de l\'article est requis',
+      'string.min': 'Le titre de l\'article doit contenir au moins 1 caractère',
+      'string.max': 'Le titre de l\'article ne peut pas dépasser 200 caractères',
+      'any.required': 'Le titre de l\'article est requis'
+    }),
+  content: Joi.string()
+    .min(1)
+    .required()
+    .messages({
+      'string.empty': 'Le contenu de l\'article est requis',
+      'string.min': 'Le contenu de l\'article doit contenir au moins 1 caractère',
+      'any.required': 'Le contenu de l\'article est requis'
+    }),
+  status: Joi.string()
+    .valid('draft', 'published', 'hided')
+    .default('draft')
+    .messages({
+      'any.only': 'Le statut doit être draft, published ou hided'
+    })
+});
+
+// Schéma pour la mise à jour d'un article
+export const updateArticleSchema = Joi.object({
+  categoryId: Joi.string()
+    .uuid()
+    .optional()
+    .messages({
+      'string.guid': 'L\'ID de la catégorie doit être un UUID valide'
+    }),
+  title: Joi.string()
+    .min(1)
+    .max(200)
+    .optional()
+    .messages({
+      'string.min': 'Le titre de l\'article doit contenir au moins 1 caractère',
+      'string.max': 'Le titre de l\'article ne peut pas dépasser 200 caractères'
+    }),
+  content: Joi.string()
+    .min(1)
+    .optional()
+    .messages({
+      'string.min': 'Le contenu de l\'article doit contenir au moins 1 caractère'
+    }),
+  status: Joi.string()
+    .valid('draft', 'published', 'hided')
+    .optional()
+    .messages({
+      'any.only': 'Le statut doit être draft, published ou hided'
+    })
+}).min(1).messages({
+  'object.min': 'Au moins un champ doit être fourni pour la mise à jour'
+});
+
+// Schéma pour les paramètres de requête (pagination, recherche, filtres)
+export const getArticlesQuerySchema = Joi.object({
+  page: Joi.number()
+    .integer()
+    .min(1)
+    .default(1)
+    .messages({
+      'number.base': 'La page doit être un nombre',
+      'number.integer': 'La page doit être un nombre entier',
+      'number.min': 'La page doit être supérieure ou égale à 1'
+    }),
+  limit: Joi.number()
+    .integer()
+    .min(1)
+    .max(100)
+    .default(10)
+    .messages({
+      'number.base': 'La limite doit être un nombre',
+      'number.integer': 'La limite doit être un nombre entier',
+      'number.min': 'La limite doit être supérieure ou égale à 1',
+      'number.max': 'La limite ne peut pas dépasser 100'
+    }),
+  search: Joi.string()
+    .min(1)
+    .max(100)
+    .optional()
+    .messages({
+      'string.min': 'Le terme de recherche doit contenir au moins 1 caractère',
+      'string.max': 'Le terme de recherche ne peut pas dépasser 100 caractères'
+    }),
+  status: Joi.string()
+    .valid('draft', 'published', 'hided')
+    .optional()
+    .messages({
+      'any.only': 'Le statut doit être draft, published ou hided'
+    }),
+  categoryId: Joi.string()
+    .uuid()
+    .optional()
+    .messages({
+      'string.guid': 'L\'ID de la catégorie doit être un UUID valide'
+    }),
+  userId: Joi.string()
+    .uuid()
+    .optional()
+    .messages({
+      'string.guid': 'L\'ID de l\'utilisateur doit être un UUID valide'
+    }),
+  sortBy: Joi.string()
+    .valid('title', 'createdAt', 'updatedAt', 'status')
+    .default('createdAt')
+    .messages({
+      'any.only': 'Le tri doit être par title, createdAt, updatedAt ou status'
+    }),
+  sortOrder: Joi.string()
+    .valid('ASC', 'DESC')
+    .default('DESC')
+    .messages({
+      'any.only': 'L\'ordre de tri doit être ASC ou DESC'
+    })
+});
+
+// Schéma pour les paramètres d'ID
+export const articleIdParamSchema = Joi.object({
+  id: Joi.string()
+    .uuid()
+    .required()
+    .messages({
+      'string.guid': 'L\'ID de l\'article doit être un UUID valide',
+      'any.required': 'L\'ID de l\'article est requis'
+    })
+});
+
+// Schéma pour changer le statut d'un article
+export const changeArticleStatusSchema = Joi.object({
+  status: Joi.string()
+    .valid('draft', 'published', 'hided')
+    .required()
+    .messages({
+      'any.only': 'Le statut doit être draft, published ou hided',
+      'any.required': 'Le statut est requis'
+    })
+});


### PR DESCRIPTION
- Create Article model with id, userId, categoryId, title, content, status fields
- Add Article controller with create, read, update, delete operations
- Implement user-only access for own articles, admin access for all articles
- Add public access for read operations (GET endpoints)
- Create comprehensive validation schemas for all operations
- Add complete test suite (36 tests) for Article functionality
- Integrate Article routes into main application
- Update database initialization to include Article model and associations
- Add articleAuthorOrAdminScope middleware for proper authorization
- Support article status management (draft, published, hided)
- Include search, pagination, and filtering capabilities

Features:
- GET /api/articles - List all articles (public)
- GET /api/articles/:id - Get article by ID (public)
- POST /api/articles - Create article (authenticated users)
- PUT /api/articles/:id - Update article (author or admin)
- DELETE /api/articles/:id - Delete article (author or admin)
- PATCH /api/articles/:id/status - Change article status (author or admin)
- Full relationship support with User and Category models
- Comprehensive error handling and validation