### PR TITLE
feat: Add LikeArticle entity with reaction system

### DIFF
--- a/server/src/__tests__/integration/likeArticle.integration.test.ts
+++ b/server/src/__tests__/integration/likeArticle.integration.test.ts
@@ -1,0 +1,480 @@
+import request from 'supertest';
+import app from '../../app';
+import { LikeArticle } from '../../models/LikeArticle';
+import { Article } from '../../models/Article';
+import { Category } from '../../models/Category';
+import { User } from '../../models/User';
+import { Session } from '../../models/Session';
+import { sequelize } from '../../db/sequelize';
+import { initDatabase } from '../../db/sequelize';
+import { 
+  generateTestToken,
+  hashTestToken,
+  cleanupAuth
+} from '../fixtures/auth.fixtures';
+import { 
+  userFixtures, 
+  createUserInDb,
+  cleanupUsers
+} from '../fixtures/user.fixtures';
+
+// Fonction de nettoyage
+const cleanupLikeArticles = async (): Promise<void> => {
+  await LikeArticle.destroy({ where: {}, force: true });
+};
+
+const cleanupArticles = async (): Promise<void> => {
+  await Article.destroy({ where: {}, force: true });
+};
+
+const cleanupCategories = async (): Promise<void> => {
+  await Category.destroy({ where: {}, force: true });
+};
+
+describe('LikeArticle Integration Tests', () => {
+  let adminUser: User;
+  let regularUser: User;
+  let adminToken: string;
+  let adminSession: Session;
+  let userToken: string;
+  let userSession: Session;
+  let category: Category;
+  let article: Article;
+
+  beforeAll(async () => {
+    await initDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanupLikeArticles();
+    await cleanupArticles();
+    await cleanupCategories();
+    await cleanupUsers();
+    await cleanupAuth();
+
+    // Créer un utilisateur admin
+    adminUser = await createUserInDb(userFixtures.admin);
+    adminToken = generateTestToken(adminUser.id);
+    const adminTokenHash = await hashTestToken(adminToken);
+    adminSession = await Session.create({
+      userId: adminUser.id,
+      tokenHash: adminTokenHash,
+      ipAddress: '127.0.0.1',
+      userAgent: 'Mozilla/5.0 (Test Browser)',
+      isActive: true,
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+    });
+
+    // Créer un utilisateur régulier
+    regularUser = await createUserInDb(userFixtures.regular);
+    userToken = generateTestToken(regularUser.id);
+    const userTokenHash = await hashTestToken(userToken);
+    userSession = await Session.create({
+      userId: regularUser.id,
+      tokenHash: userTokenHash,
+      ipAddress: '127.0.0.1',
+      userAgent: 'Mozilla/5.0 (Test Browser)',
+      isActive: true,
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+    });
+
+    // Créer une catégorie
+    category = await Category.create({
+      name: 'Technology',
+      description: 'Articles about technology'
+    });
+
+    // Créer un article
+    article = await Article.create({
+      userId: regularUser.id,
+      categoryId: category.id,
+      title: 'Test Article',
+      content: 'Test content',
+      status: 'published'
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupLikeArticles();
+    await cleanupArticles();
+    await cleanupCategories();
+    await cleanupUsers();
+    await cleanupAuth();
+  });
+
+  describe('Complete LikeArticle Workflow', () => {
+    it('should handle complete like lifecycle', async () => {
+      // 1. Créer un like
+      const createResponse = await request(app)
+        .post('/api/like-articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({
+          articleId: article.id,
+          type: 'like'
+        })
+        .expect(201);
+
+      expect(createResponse.body.success).toBe(true);
+      expect(createResponse.body.data.type).toBe('like');
+      const likeId = createResponse.body.data.id;
+
+      // 2. Récupérer le like créé
+      const getResponse = await request(app)
+        .get(`/api/like-articles/${likeId}`)
+        .expect(200);
+
+      expect(getResponse.body.success).toBe(true);
+      expect(getResponse.body.data.id).toBe(likeId);
+      expect(getResponse.body.data.type).toBe('like');
+
+      // 3. Lister tous les likes
+      const listResponse = await request(app)
+        .get('/api/like-articles')
+        .expect(200);
+
+      expect(listResponse.body.success).toBe(true);
+      expect(listResponse.body.data.data).toHaveLength(1);
+      expect(listResponse.body.data.data[0].type).toBe('like');
+
+      // 4. Mettre à jour le like
+      const updateResponse = await request(app)
+        .put(`/api/like-articles/${likeId}`)
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({
+          type: 'love'
+        })
+        .expect(200);
+
+      expect(updateResponse.body.success).toBe(true);
+      expect(updateResponse.body.data.type).toBe('love');
+
+      // 5. Vérifier que le like a été mis à jour
+      const updatedGetResponse = await request(app)
+        .get(`/api/like-articles/${likeId}`)
+        .expect(200);
+
+      expect(updatedGetResponse.body.success).toBe(true);
+      expect(updatedGetResponse.body.data.type).toBe('love');
+
+      // 6. Supprimer le like
+      const deleteResponse = await request(app)
+        .delete(`/api/like-articles/${likeId}`)
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .expect(200);
+
+      expect(deleteResponse.body.success).toBe(true);
+      expect(deleteResponse.body.message).toBe('Like supprimé avec succès');
+
+      // 7. Vérifier que le like a été supprimé
+      const deletedGetResponse = await request(app)
+        .get(`/api/like-articles/${likeId}`)
+        .expect(404);
+
+      expect(deletedGetResponse.body.success).toBe(false);
+    }, 30000);
+
+    it('should handle multiple likes with different types', async () => {
+      // Créer plusieurs utilisateurs et likes avec différents types
+      const likeTypes = ['like', 'love', 'care', 'haha', 'wow', 'sad', 'angry'];
+
+      for (let i = 0; i < likeTypes.length; i++) {
+        const testUser = await createUserInDb({
+          firstname: `Test${i}`,
+          lastname: `User${i}`,
+          email: `test${i}@example.com`,
+          password: 'password123'
+        });
+        const testToken = generateTestToken(testUser.id);
+        const testTokenHash = await hashTestToken(testToken);
+        const testSession = await Session.create({
+          userId: testUser.id,
+          tokenHash: testTokenHash,
+          ipAddress: '127.0.0.1',
+          userAgent: 'Mozilla/5.0 (Test Browser)',
+          isActive: true,
+          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+        });
+
+        await request(app)
+          .post('/api/like-articles')
+          .set('Cookie', [
+            `sessionId=${testSession.id}`,
+            `token=${testToken}`
+          ])
+          .send({
+            articleId: article.id,
+            type: likeTypes[i] as any
+          })
+          .expect(201);
+      }
+
+      // Tester la pagination
+      const page1Response = await request(app)
+        .get('/api/like-articles?page=1&limit=3')
+        .expect(200);
+
+      expect(page1Response.body.success).toBe(true);
+      expect(page1Response.body.data.data).toHaveLength(3);
+      expect(page1Response.body.data.pagination.total).toBe(7);
+      expect(page1Response.body.data.pagination.totalPages).toBe(3);
+
+      // Tester le filtrage par type
+      const likeResponse = await request(app)
+        .get('/api/like-articles?type=like')
+        .expect(200);
+
+      expect(likeResponse.body.success).toBe(true);
+      expect(likeResponse.body.data.data).toHaveLength(1);
+      expect(likeResponse.body.data.data[0].type).toBe('like');
+
+      // Tester le tri
+      const sortedResponse = await request(app)
+        .get('/api/like-articles?sortBy=type&sortOrder=ASC')
+        .expect(200);
+
+      expect(sortedResponse.body.success).toBe(true);
+      const types = sortedResponse.body.data.data.map((like: any) => like.type);
+      expect(types).toEqual(['angry', 'care', 'haha', 'like', 'love', 'sad', 'wow']);
+    }, 30000);
+
+    it('should handle like statistics correctly', async () => {
+      // Créer des likes de différents types avec différents utilisateurs
+      const likeData = [
+        { type: 'like', count: 3 },
+        { type: 'love', count: 2 },
+        { type: 'haha', count: 1 },
+        { type: 'wow', count: 1 }
+      ];
+
+      for (const { type, count } of likeData) {
+        for (let i = 0; i < count; i++) {
+          const testUser = await createUserInDb({
+            firstname: `Test${type}${i}`,
+            lastname: `User${type}${i}`,
+            email: `test${type}${i}@example.com`,
+            password: 'password123'
+          });
+          const testToken = generateTestToken(testUser.id);
+          const testTokenHash = await hashTestToken(testToken);
+          const testSession = await Session.create({
+            userId: testUser.id,
+            tokenHash: testTokenHash,
+            ipAddress: '127.0.0.1',
+            userAgent: 'Mozilla/5.0 (Test Browser)',
+            isActive: true,
+            expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+          });
+
+          await request(app)
+            .post('/api/like-articles')
+            .set('Cookie', [
+              `sessionId=${testSession.id}`,
+              `token=${testToken}`
+            ])
+            .send({
+              articleId: article.id,
+              type: type as any
+            })
+            .expect(201);
+        }
+      }
+
+      // Obtenir les statistiques
+      const statsResponse = await request(app)
+        .get(`/api/like-articles/stats/${article.id}`)
+        .expect(200);
+
+      expect(statsResponse.body.success).toBe(true);
+      expect(statsResponse.body.data.articleId).toBe(article.id);
+      expect(statsResponse.body.data.stats.like).toBe(3);
+      expect(statsResponse.body.data.stats.love).toBe(2);
+      expect(statsResponse.body.data.stats.haha).toBe(1);
+      expect(statsResponse.body.data.stats.wow).toBe(1);
+      expect(statsResponse.body.data.stats.total).toBe(7);
+    }, 30000);
+
+    it('should handle admin permissions correctly', async () => {
+      // Créer un like en tant qu'utilisateur régulier
+      const createResponse = await request(app)
+        .post('/api/like-articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({
+          articleId: article.id,
+          type: 'like'
+        })
+        .expect(201);
+
+      const likeId = createResponse.body.data.id;
+
+      // Admin peut modifier le like d'un autre utilisateur
+      const adminUpdateResponse = await request(app)
+        .put(`/api/like-articles/${likeId}`)
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send({
+          type: 'love'
+        })
+        .expect(200);
+
+      expect(adminUpdateResponse.body.success).toBe(true);
+      expect(adminUpdateResponse.body.data.type).toBe('love');
+
+      // Admin peut supprimer le like
+      const adminDeleteResponse = await request(app)
+        .delete(`/api/like-articles/${likeId}`)
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .expect(200);
+
+      expect(adminDeleteResponse.body.success).toBe(true);
+      expect(adminDeleteResponse.body.message).toBe('Like supprimé avec succès');
+    }, 30000);
+
+    it('should handle like update when user already liked', async () => {
+      // Créer un like initial
+      const createResponse = await request(app)
+        .post('/api/like-articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({
+          articleId: article.id,
+          type: 'like'
+        })
+        .expect(201);
+
+      const likeId = createResponse.body.data.id;
+
+      // Essayer de créer un nouveau like pour le même article
+      const updateResponse = await request(app)
+        .post('/api/like-articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({
+          articleId: article.id,
+          type: 'love'
+        })
+        .expect(200);
+
+      expect(updateResponse.body.success).toBe(true);
+      expect(updateResponse.body.message).toBe('Like mis à jour avec succès');
+      expect(updateResponse.body.data.type).toBe('love');
+      expect(updateResponse.body.data.id).toBe(likeId); // Même ID, donc mis à jour
+    }, 30000);
+  });
+
+  describe('Error Handling', () => {
+    it('should handle invalid like ID', async () => {
+      const response = await request(app)
+        .get('/api/like-articles/invalid-id')
+        .expect(400);
+
+      expect(response.body.success).toBe(false);
+    });
+
+    it('should handle non-existent like', async () => {
+      const response = await request(app)
+        .get('/api/like-articles/00000000-0000-0000-0000-000000000000')
+        .expect(404);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.data).toBeNull();
+    });
+
+    it('should handle unauthorized access to protected routes', async () => {
+      // Essayer de créer un like sans authentification
+      const createResponse = await request(app)
+        .post('/api/like-articles')
+        .send({
+          articleId: article.id,
+          type: 'like'
+        })
+        .expect(401);
+
+      expect(createResponse.body.success).toBe(false);
+
+      // Essayer de mettre à jour un like sans authentification
+      const updateResponse = await request(app)
+        .put('/api/like-articles/00000000-0000-0000-0000-000000000000')
+        .send({
+          type: 'love'
+        })
+        .expect(401);
+
+      expect(updateResponse.body.success).toBe(false);
+    });
+
+    it('should handle validation errors', async () => {
+      // Créer un like avec des données invalides
+      const invalidResponse = await request(app)
+        .post('/api/like-articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({
+          articleId: 'invalid-uuid',
+          type: 'invalid'
+        })
+        .expect(400);
+
+      expect(invalidResponse.body.success).toBe(false);
+
+      // Mettre à jour avec des données invalides
+      const like = await LikeArticle.create({
+        userId: regularUser.id,
+        articleId: article.id,
+        type: 'like'
+      });
+
+      const invalidUpdateResponse = await request(app)
+        .put(`/api/like-articles/${like.id}`)
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({
+          type: 'invalid'
+        })
+        .expect(400);
+
+      expect(invalidUpdateResponse.body.success).toBe(false);
+    });
+
+    it('should handle non-existent article when creating like', async () => {
+      const response = await request(app)
+        .post('/api/like-articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({
+          articleId: '00000000-0000-0000-0000-000000000000',
+          type: 'like'
+        })
+        .expect(404);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Article non trouvé');
+    });
+  });
+});

--- a/server/src/__tests__/unit/likeArticle.test.ts
+++ b/server/src/__tests__/unit/likeArticle.test.ts
@@ -1,0 +1,658 @@
+import request from 'supertest';
+import app from '../../app';
+import { LikeArticle } from '../../models/LikeArticle';
+import { Article } from '../../models/Article';
+import { Category } from '../../models/Category';
+import { User } from '../../models/User';
+import { Session } from '../../models/Session';
+import { sequelize } from '../../db/sequelize';
+import { initDatabase } from '../../db/sequelize';
+import { 
+  generateTestToken,
+  hashTestToken,
+  cleanupAuth
+} from '../fixtures/auth.fixtures';
+import { 
+  userFixtures, 
+  createUserInDb,
+  cleanupUsers
+} from '../fixtures/user.fixtures';
+
+// Fonction de nettoyage
+const cleanupLikeArticles = async (): Promise<void> => {
+  await LikeArticle.destroy({ where: {}, force: true });
+};
+
+const cleanupArticles = async (): Promise<void> => {
+  await Article.destroy({ where: {}, force: true });
+};
+
+const cleanupCategories = async (): Promise<void> => {
+  await Category.destroy({ where: {}, force: true });
+};
+
+describe('LikeArticle CRUD Operations', () => {
+  let adminUser: User;
+  let regularUser: User;
+  let adminToken: string;
+  let adminSession: Session;
+  let userToken: string;
+  let userSession: Session;
+  let category: Category;
+  let article: Article;
+
+  beforeAll(async () => {
+    await initDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanupLikeArticles();
+    await cleanupArticles();
+    await cleanupCategories();
+    await cleanupUsers();
+    await cleanupAuth();
+
+    // Créer un utilisateur admin
+    adminUser = await createUserInDb(userFixtures.admin);
+    adminToken = generateTestToken(adminUser.id);
+    const adminTokenHash = await hashTestToken(adminToken);
+    adminSession = await Session.create({
+      userId: adminUser.id,
+      tokenHash: adminTokenHash,
+      ipAddress: '127.0.0.1',
+      userAgent: 'Mozilla/5.0 (Test Browser)',
+      isActive: true,
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+    });
+
+    // Créer un utilisateur régulier
+    regularUser = await createUserInDb(userFixtures.regular);
+    userToken = generateTestToken(regularUser.id);
+    const userTokenHash = await hashTestToken(userToken);
+    userSession = await Session.create({
+      userId: regularUser.id,
+      tokenHash: userTokenHash,
+      ipAddress: '127.0.0.1',
+      userAgent: 'Mozilla/5.0 (Test Browser)',
+      isActive: true,
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+    });
+
+    // Créer une catégorie
+    category = await Category.create({
+      name: 'Technology',
+      description: 'Articles about technology'
+    });
+
+    // Créer un article
+    article = await Article.create({
+      userId: regularUser.id,
+      categoryId: category.id,
+      title: 'Test Article',
+      content: 'Test content',
+      status: 'published'
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupLikeArticles();
+    await cleanupArticles();
+    await cleanupCategories();
+    await cleanupUsers();
+    await cleanupAuth();
+  });
+
+  describe('GET /api/like-articles', () => {
+    it('should get all likes without authentication', async () => {
+      // Créer quelques likes de test
+      await LikeArticle.create({
+        userId: regularUser.id,
+        articleId: article.id,
+        type: 'like'
+      });
+      await LikeArticle.create({
+        userId: adminUser.id,
+        articleId: article.id,
+        type: 'love'
+      });
+
+      const response = await request(app)
+        .get('/api/like-articles')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.data).toHaveLength(2);
+      expect(response.body.data.pagination.total).toBe(2);
+    });
+
+    it('should get likes with pagination', async () => {
+      // Créer plusieurs utilisateurs et likes
+      for (let i = 1; i <= 15; i++) {
+        const testUser = await createUserInDb({
+          firstname: `Test${i}`,
+          lastname: `User${i}`,
+          email: `test${i}@example.com`,
+          password: 'password123'
+        });
+        await LikeArticle.create({
+          userId: testUser.id,
+          articleId: article.id,
+          type: 'like'
+        });
+      }
+
+      const response = await request(app)
+        .get('/api/like-articles?page=1&limit=5')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.data).toHaveLength(5);
+      expect(response.body.data.pagination.page).toBe(1);
+      expect(response.body.data.pagination.limit).toBe(5);
+      expect(response.body.data.pagination.total).toBe(15);
+      expect(response.body.data.pagination.totalPages).toBe(3);
+    }, 30000);
+
+    it('should filter likes by type', async () => {
+      await LikeArticle.create({
+        userId: regularUser.id,
+        articleId: article.id,
+        type: 'like'
+      });
+      await LikeArticle.create({
+        userId: adminUser.id,
+        articleId: article.id,
+        type: 'love'
+      });
+
+      const response = await request(app)
+        .get('/api/like-articles?type=like')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.data).toHaveLength(1);
+      expect(response.body.data.data[0].type).toBe('like');
+    });
+
+    it('should filter likes by article', async () => {
+      const article2 = await Article.create({
+        userId: regularUser.id,
+        categoryId: category.id,
+        title: 'Article 2',
+        content: 'Content 2',
+        status: 'published'
+      });
+
+      await LikeArticle.create({
+        userId: regularUser.id,
+        articleId: article.id,
+        type: 'like'
+      });
+      await LikeArticle.create({
+        userId: adminUser.id,
+        articleId: article2.id,
+        type: 'love'
+      });
+
+      const response = await request(app)
+        .get(`/api/like-articles?articleId=${article.id}`)
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.data).toHaveLength(1);
+      expect(response.body.data.data[0].articleId).toBe(article.id);
+    });
+
+    it('should filter likes by user', async () => {
+      await LikeArticle.create({
+        userId: regularUser.id,
+        articleId: article.id,
+        type: 'like'
+      });
+      await LikeArticle.create({
+        userId: adminUser.id,
+        articleId: article.id,
+        type: 'love'
+      });
+
+      const response = await request(app)
+        .get(`/api/like-articles?userId=${regularUser.id}`)
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.data).toHaveLength(1);
+      expect(response.body.data.data[0].userId).toBe(regularUser.id);
+    });
+
+    it('should sort likes', async () => {
+      await LikeArticle.create({
+        userId: regularUser.id,
+        articleId: article.id,
+        type: 'angry'
+      });
+      await LikeArticle.create({
+        userId: adminUser.id,
+        articleId: article.id,
+        type: 'like'
+      });
+
+      const response = await request(app)
+        .get('/api/like-articles?sortBy=type&sortOrder=ASC')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.data[0].type).toBe('angry');
+      expect(response.body.data.data[1].type).toBe('like');
+    });
+  });
+
+  describe('GET /api/like-articles/:id', () => {
+    it('should get a like by ID without authentication', async () => {
+      const like = await LikeArticle.create({
+        userId: regularUser.id,
+        articleId: article.id,
+        type: 'like'
+      });
+
+      const response = await request(app)
+        .get(`/api/like-articles/${like.id}`)
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.id).toBe(like.id);
+      expect(response.body.data.type).toBe('like');
+    });
+
+    it('should return 404 for non-existent like', async () => {
+      const response = await request(app)
+        .get('/api/like-articles/00000000-0000-0000-0000-000000000000')
+        .expect(404);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.data).toBeNull();
+    });
+
+    it('should return 400 for invalid UUID', async () => {
+      const response = await request(app)
+        .get('/api/like-articles/invalid-id')
+        .expect(400);
+
+      expect(response.body.success).toBe(false);
+    });
+  });
+
+  describe('GET /api/like-articles/stats/:articleId', () => {
+    it('should get like statistics for an article', async () => {
+      // Créer des utilisateurs supplémentaires pour les likes
+      const user1 = await createUserInDb({
+        firstname: 'User1',
+        lastname: 'Test',
+        email: 'user1@example.com',
+        password: 'password123'
+      });
+      const user2 = await createUserInDb({
+        firstname: 'User2',
+        lastname: 'Test',
+        email: 'user2@example.com',
+        password: 'password123'
+      });
+
+      // Créer des likes de différents types
+      await LikeArticle.create({
+        userId: regularUser.id,
+        articleId: article.id,
+        type: 'like'
+      });
+      await LikeArticle.create({
+        userId: user1.id,
+        articleId: article.id,
+        type: 'like'
+      });
+      await LikeArticle.create({
+        userId: user2.id,
+        articleId: article.id,
+        type: 'love'
+      });
+
+      const response = await request(app)
+        .get(`/api/like-articles/stats/${article.id}`)
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.articleId).toBe(article.id);
+      expect(response.body.data.stats.like).toBe(2);
+      expect(response.body.data.stats.love).toBe(1);
+      expect(response.body.data.stats.total).toBe(3);
+    });
+
+    it('should return empty stats for non-existent article', async () => {
+      const response = await request(app)
+        .get('/api/like-articles/stats/00000000-0000-0000-0000-000000000000')
+        .expect(404);
+
+      expect(response.body.success).toBe(false);
+    });
+  });
+
+  describe('POST /api/like-articles', () => {
+    it('should create a like as authenticated user', async () => {
+      const likeData = {
+        articleId: article.id,
+        type: 'like'
+      };
+
+      const response = await request(app)
+        .post('/api/like-articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send(likeData)
+        .expect(201);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.message).toBe('Like créé avec succès');
+      expect(response.body.data.type).toBe('like');
+      expect(response.body.data.userId).toBe(regularUser.id);
+    });
+
+    it('should update existing like if user already liked the article', async () => {
+      // Créer un like initial
+      await LikeArticle.create({
+        userId: regularUser.id,
+        articleId: article.id,
+        type: 'like'
+      });
+
+      const likeData = {
+        articleId: article.id,
+        type: 'love'
+      };
+
+      const response = await request(app)
+        .post('/api/like-articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send(likeData)
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.message).toBe('Like mis à jour avec succès');
+      expect(response.body.data.type).toBe('love');
+    });
+
+    it('should deny access without authentication', async () => {
+      const likeData = {
+        articleId: article.id,
+        type: 'like'
+      };
+
+      const response = await request(app)
+        .post('/api/like-articles')
+        .send(likeData)
+        .expect(401);
+
+      expect(response.body.success).toBe(false);
+    });
+
+    it('should return 404 for non-existent article', async () => {
+      const likeData = {
+        articleId: '00000000-0000-0000-0000-000000000000',
+        type: 'like'
+      };
+
+      const response = await request(app)
+        .post('/api/like-articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send(likeData)
+        .expect(404);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Article non trouvé');
+    });
+
+    it('should validate required fields', async () => {
+      const response = await request(app)
+        .post('/api/like-articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send({})
+        .expect(400);
+
+      expect(response.body.success).toBe(false);
+    });
+
+    it('should validate type values', async () => {
+      const likeData = {
+        articleId: article.id,
+        type: 'invalid'
+      };
+
+      const response = await request(app)
+        .post('/api/like-articles')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send(likeData)
+        .expect(400);
+
+      expect(response.body.success).toBe(false);
+    });
+  });
+
+  describe('PUT /api/like-articles/:id', () => {
+    let like: LikeArticle;
+
+    beforeEach(async () => {
+      like = await LikeArticle.create({
+        userId: regularUser.id,
+        articleId: article.id,
+        type: 'like'
+      });
+    });
+
+    it('should update a like as the author', async () => {
+      const updateData = {
+        type: 'love'
+      };
+
+      const response = await request(app)
+        .put(`/api/like-articles/${like.id}`)
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send(updateData)
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.message).toBe('Like mis à jour avec succès');
+      expect(response.body.data.type).toBe('love');
+    });
+
+    it('should update a like as admin', async () => {
+      const updateData = {
+        type: 'angry'
+      };
+
+      const response = await request(app)
+        .put(`/api/like-articles/${like.id}`)
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .send(updateData)
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.type).toBe('angry');
+    });
+
+    it('should deny access to other users', async () => {
+      const otherUser = await createUserInDb({
+        firstname: 'Other',
+        lastname: 'User',
+        email: 'other@example.com',
+        password: 'password123'
+      });
+      const otherToken = generateTestToken(otherUser.id);
+      const otherTokenHash = await hashTestToken(otherToken);
+      const otherSession = await Session.create({
+        userId: otherUser.id,
+        tokenHash: otherTokenHash,
+        ipAddress: '127.0.0.1',
+        userAgent: 'Mozilla/5.0 (Test Browser)',
+        isActive: true,
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+      });
+
+      const updateData = {
+        type: 'love'
+      };
+
+      const response = await request(app)
+        .put(`/api/like-articles/${like.id}`)
+        .set('Cookie', [
+          `sessionId=${otherSession.id}`,
+          `token=${otherToken}`
+        ])
+        .send(updateData)
+        .expect(403);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Vous ne pouvez modifier que vos propres likes');
+    });
+
+    it('should deny access without authentication', async () => {
+      const updateData = {
+        type: 'love'
+      };
+
+      const response = await request(app)
+        .put(`/api/like-articles/${like.id}`)
+        .send(updateData)
+        .expect(401);
+
+      expect(response.body.success).toBe(false);
+    });
+
+    it('should return 404 for non-existent like', async () => {
+      const updateData = {
+        type: 'love'
+      };
+
+      const response = await request(app)
+        .put('/api/like-articles/00000000-0000-0000-0000-000000000000')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .send(updateData)
+        .expect(404);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Like non trouvé');
+    });
+  });
+
+  describe('DELETE /api/like-articles/:id', () => {
+    let like: LikeArticle;
+
+    beforeEach(async () => {
+      like = await LikeArticle.create({
+        userId: regularUser.id,
+        articleId: article.id,
+        type: 'like'
+      });
+    });
+
+    it('should delete a like as the author', async () => {
+      const response = await request(app)
+        .delete(`/api/like-articles/${like.id}`)
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.message).toBe('Like supprimé avec succès');
+
+      // Vérifier que le like a été supprimé
+      const deletedLike = await LikeArticle.findByPk(like.id);
+      expect(deletedLike).toBeNull();
+    });
+
+    it('should delete a like as admin', async () => {
+      const response = await request(app)
+        .delete(`/api/like-articles/${like.id}`)
+        .set('Cookie', [
+          `sessionId=${adminSession.id}`,
+          `token=${adminToken}`
+        ])
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.message).toBe('Like supprimé avec succès');
+    });
+
+    it('should deny access to other users', async () => {
+      const otherUser = await createUserInDb({
+        firstname: 'Other',
+        lastname: 'User',
+        email: 'other@example.com',
+        password: 'password123'
+      });
+      const otherToken = generateTestToken(otherUser.id);
+      const otherTokenHash = await hashTestToken(otherToken);
+      const otherSession = await Session.create({
+        userId: otherUser.id,
+        tokenHash: otherTokenHash,
+        ipAddress: '127.0.0.1',
+        userAgent: 'Mozilla/5.0 (Test Browser)',
+        isActive: true,
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+      });
+
+      const response = await request(app)
+        .delete(`/api/like-articles/${like.id}`)
+        .set('Cookie', [
+          `sessionId=${otherSession.id}`,
+          `token=${otherToken}`
+        ])
+        .expect(403);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Vous ne pouvez supprimer que vos propres likes');
+    });
+
+    it('should deny access without authentication', async () => {
+      const response = await request(app)
+        .delete(`/api/like-articles/${like.id}`)
+        .expect(401);
+
+      expect(response.body.success).toBe(false);
+    });
+
+    it('should return 404 for non-existent like', async () => {
+      const response = await request(app)
+        .delete('/api/like-articles/00000000-0000-0000-0000-000000000000')
+        .set('Cookie', [
+          `sessionId=${userSession.id}`,
+          `token=${userToken}`
+        ])
+        .expect(404);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Like non trouvé');
+    });
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -8,6 +8,7 @@ import userRoutes from './routes/user.routes';
 import authRoutes from './routes/auth.routes';
 import categoryRoutes from './routes/category.routes';
 import articleRoutes from './routes/article.routes';
+import likeArticleRoutes from './routes/likeArticle.routes';
 import { errorHandler } from './middleware/validation';
 
 const app = express();
@@ -36,6 +37,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/categories', categoryRoutes);
 app.use('/api/articles', articleRoutes);
+app.use('/api/like-articles', likeArticleRoutes);
 
 // Middleware de gestion d'erreurs (doit être en dernier)
 app.use(errorHandler);

--- a/server/src/controllers/likeArticle.controllers.ts
+++ b/server/src/controllers/likeArticle.controllers.ts
@@ -1,0 +1,515 @@
+import { Request, Response } from 'express';
+import { LikeArticle } from '../models/LikeArticle';
+import { Article } from '../models/Article';
+import { User } from '../models/User';
+import { Op } from 'sequelize';
+import { AuthenticatedRequest } from '../middleware/auth';
+
+// Interfaces pour les requêtes
+export interface IReqCreateLikeArticle {
+  articleId: string;
+  type: 'like' | 'love' | 'care' | 'haha' | 'wow' | 'sad' | 'angry';
+}
+
+export interface IReqUpdateLikeArticle {
+  type: 'like' | 'love' | 'care' | 'haha' | 'wow' | 'sad' | 'angry';
+}
+
+export interface IReqLikeArticleParams {
+  id: string;
+}
+
+export interface IReqLikeArticleQuery {
+  page?: number;
+  limit?: number;
+  type?: 'like' | 'love' | 'care' | 'haha' | 'wow' | 'sad' | 'angry';
+  articleId?: string;
+  userId?: string;
+  sortBy?: 'createdAt' | 'updatedAt' | 'type';
+  sortOrder?: 'ASC' | 'DESC';
+}
+
+export interface IReqArticleParams {
+  articleId: string;
+}
+
+// Interfaces pour les réponses
+export interface IResLikeArticle {
+  id: string;
+  userId: string;
+  articleId: string;
+  type: 'like' | 'love' | 'care' | 'haha' | 'wow' | 'sad' | 'angry';
+  createdAt: Date;
+  updatedAt: Date;
+  User?: {
+    id: string;
+    firstname: string;
+    lastname: string;
+    email: string;
+  };
+  Article?: {
+    id: string;
+    title: string;
+    content: string;
+    status: string;
+  };
+}
+
+export interface IResCreateLikeArticle {
+  success: boolean;
+  message: string;
+  data: IResLikeArticle | null;
+}
+
+export interface IResGetLikeArticle {
+  success: boolean;
+  data: IResLikeArticle | null;
+}
+
+export interface IResUpdateLikeArticle {
+  success: boolean;
+  message: string;
+  data: IResLikeArticle | null;
+}
+
+export interface IResGetLikeArticles {
+  success: boolean;
+  data: {
+    data: IResLikeArticle[];
+    pagination: {
+      page: number;
+      limit: number;
+      total: number;
+      totalPages: number;
+    };
+  };
+}
+
+export interface IResDeleteLikeArticle {
+  success: boolean;
+  message: string;
+}
+
+export interface IResLikeStats {
+  success: boolean;
+  data: {
+    articleId: string;
+    stats: {
+      like: number;
+      love: number;
+      care: number;
+      haha: number;
+      wow: number;
+      sad: number;
+      angry: number;
+      total: number;
+    };
+  };
+}
+
+// Créer un like pour un article
+export const createLikeArticle = async (req: AuthenticatedRequest<IReqLikeArticleParams, IResCreateLikeArticle, IReqCreateLikeArticle>, res: Response<IResCreateLikeArticle>): Promise<void> => {
+  try {
+    const { articleId, type } = req.body;
+    const userId = req.user!.id;
+
+    // Vérifier que l'article existe
+    const article = await Article.findByPk(articleId);
+    if (!article) {
+      res.status(404).json({
+        success: false,
+        message: 'Article non trouvé',
+        data: null
+      });
+      return;
+    }
+
+    // Vérifier si l'utilisateur a déjà liké cet article
+    const existingLike = await LikeArticle.findOne({
+      where: { userId, articleId }
+    });
+
+    if (existingLike) {
+      // Mettre à jour le type de like existant
+      await existingLike.update({ type });
+
+      // Récupérer le like mis à jour avec les relations
+      const updatedLike = await LikeArticle.findByPk(existingLike.id, {
+        include: [
+          {
+            model: User,
+            as: 'User',
+            attributes: ['id', 'firstname', 'lastname', 'email']
+          },
+          {
+            model: Article,
+            as: 'Article',
+            attributes: ['id', 'title', 'content', 'status']
+          }
+        ]
+      });
+
+      res.status(200).json({
+        success: true,
+        message: 'Like mis à jour avec succès',
+        data: updatedLike as IResLikeArticle
+      });
+      return;
+    }
+
+    // Créer un nouveau like
+    const like = await LikeArticle.create({
+      userId,
+      articleId,
+      type
+    });
+
+    // Récupérer le like avec les relations
+    const likeWithRelations = await LikeArticle.findByPk(like.id, {
+      include: [
+        {
+          model: User,
+          as: 'User',
+          attributes: ['id', 'firstname', 'lastname', 'email']
+        },
+        {
+          model: Article,
+          as: 'Article',
+          attributes: ['id', 'title', 'content', 'status']
+        }
+      ]
+    });
+
+    res.status(201).json({
+      success: true,
+      message: 'Like créé avec succès',
+      data: likeWithRelations as IResLikeArticle
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Erreur lors de la création du like:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Erreur interne du serveur',
+      data: null
+    });
+  }
+};
+
+// Obtenir tous les likes (sans protection)
+export const getLikeArticles = async (req: Request<object, IResGetLikeArticles, object, IReqLikeArticleQuery>, res: Response<IResGetLikeArticles>): Promise<void> => {
+  try {
+    const {
+      page = 1,
+      limit = 10,
+      type,
+      articleId,
+      userId,
+      sortBy = 'createdAt',
+      sortOrder = 'DESC'
+    } = req.query;
+
+    // Construire les conditions de recherche
+    const whereClause: any = {};
+    
+    if (type) {
+      whereClause.type = type;
+    }
+    
+    if (articleId) {
+      whereClause.articleId = articleId;
+    }
+    
+    if (userId) {
+      whereClause.userId = userId;
+    }
+
+    // Calculer l'offset pour la pagination
+    const offset = (page - 1) * limit;
+
+    // Récupérer les likes avec pagination
+    const { count, rows } = await LikeArticle.findAndCountAll({
+      where: whereClause,
+      include: [
+        {
+          model: User,
+          as: 'User',
+          attributes: ['id', 'firstname', 'lastname', 'email']
+        },
+        {
+          model: Article,
+          as: 'Article',
+          attributes: ['id', 'title', 'content', 'status']
+        }
+      ],
+      order: [[sortBy, sortOrder]],
+      limit: Number(limit),
+      offset: Number(offset)
+    });
+
+    const totalPages = Math.ceil(count / limit);
+
+    res.status(200).json({
+      success: true,
+      data: {
+        data: rows as IResLikeArticle[],
+        pagination: {
+          page: Number(page),
+          limit: Number(limit),
+          total: count,
+          totalPages
+        }
+      }
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Erreur lors de la récupération des likes:', error);
+    res.status(500).json({
+      success: false,
+      data: {
+        data: [],
+        pagination: {
+          page: 1,
+          limit: 10,
+          total: 0,
+          totalPages: 0
+        }
+      }
+    });
+  }
+};
+
+// Obtenir un like par ID (sans protection)
+export const getLikeArticleById = async (req: Request<IReqLikeArticleParams, IResGetLikeArticle>, res: Response<IResGetLikeArticle>): Promise<void> => {
+  try {
+    const { id } = req.params;
+
+    const like = await LikeArticle.findByPk(id, {
+      include: [
+        {
+          model: User,
+          as: 'User',
+          attributes: ['id', 'firstname', 'lastname', 'email']
+        },
+        {
+          model: Article,
+          as: 'Article',
+          attributes: ['id', 'title', 'content', 'status']
+        }
+      ]
+    });
+
+    if (!like) {
+      res.status(404).json({
+        success: false,
+        data: null
+      });
+      return;
+    }
+
+    res.status(200).json({
+      success: true,
+      data: like as IResLikeArticle
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Erreur lors de la récupération du like:', error);
+    res.status(500).json({
+      success: false,
+      data: null
+    });
+  }
+};
+
+// Mettre à jour un like
+export const updateLikeArticle = async (req: AuthenticatedRequest<IReqLikeArticleParams, IResUpdateLikeArticle, IReqUpdateLikeArticle>, res: Response<IResUpdateLikeArticle>): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const { type } = req.body;
+    const userId = req.user!.id;
+    const isAdmin = req.user!.isAdmin;
+
+    // Vérifier si le like existe
+    const like = await LikeArticle.findByPk(id);
+    if (!like) {
+      res.status(404).json({
+        success: false,
+        message: 'Like non trouvé',
+        data: null
+      });
+      return;
+    }
+
+    // Vérifier les permissions : seul l'auteur du like ou un admin peut modifier
+    if (!isAdmin && like.userId !== userId) {
+      res.status(403).json({
+        success: false,
+        message: 'Vous ne pouvez modifier que vos propres likes',
+        data: null
+      });
+      return;
+    }
+
+    // Mettre à jour le like
+    await like.update({ type });
+
+    // Récupérer le like mis à jour avec les relations
+    const updatedLike = await LikeArticle.findByPk(id, {
+      include: [
+        {
+          model: User,
+          as: 'User',
+          attributes: ['id', 'firstname', 'lastname', 'email']
+        },
+        {
+          model: Article,
+          as: 'Article',
+          attributes: ['id', 'title', 'content', 'status']
+        }
+      ]
+    });
+
+    res.status(200).json({
+      success: true,
+      message: 'Like mis à jour avec succès',
+      data: updatedLike as IResLikeArticle
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Erreur lors de la mise à jour du like:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Erreur interne du serveur',
+      data: null
+    });
+  }
+};
+
+// Supprimer un like
+export const deleteLikeArticle = async (req: AuthenticatedRequest<IReqLikeArticleParams, IResDeleteLikeArticle>, res: Response<IResDeleteLikeArticle>): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const userId = req.user!.id;
+    const isAdmin = req.user!.isAdmin;
+
+    // Vérifier si le like existe
+    const like = await LikeArticle.findByPk(id);
+    if (!like) {
+      res.status(404).json({
+        success: false,
+        message: 'Like non trouvé'
+      });
+      return;
+    }
+
+    // Vérifier les permissions : seul l'auteur du like ou un admin peut supprimer
+    if (!isAdmin && like.userId !== userId) {
+      res.status(403).json({
+        success: false,
+        message: 'Vous ne pouvez supprimer que vos propres likes'
+      });
+      return;
+    }
+
+    // Supprimer le like
+    await like.destroy();
+
+    res.status(200).json({
+      success: true,
+      message: 'Like supprimé avec succès'
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Erreur lors de la suppression du like:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Erreur interne du serveur'
+    });
+  }
+};
+
+// Obtenir les statistiques de likes pour un article
+export const getArticleLikeStats = async (req: Request<IReqArticleParams, IResLikeStats>, res: Response<IResLikeStats>): Promise<void> => {
+  try {
+    const { articleId } = req.params;
+
+    // Vérifier que l'article existe
+    const article = await Article.findByPk(articleId);
+    if (!article) {
+      res.status(404).json({
+        success: false,
+        data: {
+          articleId,
+          stats: {
+            like: 0,
+            love: 0,
+            care: 0,
+            haha: 0,
+            wow: 0,
+            sad: 0,
+            angry: 0,
+            total: 0
+          }
+        }
+      });
+      return;
+    }
+
+    // Compter les likes par type
+    const stats = await LikeArticle.findAll({
+      where: { articleId },
+      attributes: [
+        'type',
+        [LikeArticle.sequelize!.fn('COUNT', LikeArticle.sequelize!.col('type')), 'count']
+      ],
+      group: ['type']
+    });
+
+    // Initialiser les compteurs
+    const counts = {
+      like: 0,
+      love: 0,
+      care: 0,
+      haha: 0,
+      wow: 0,
+      sad: 0,
+      angry: 0,
+      total: 0
+    };
+
+    // Remplir les compteurs
+    stats.forEach((stat: any) => {
+      const type = stat.type;
+      const count = parseInt(stat.dataValues.count);
+      counts[type as keyof typeof counts] = count;
+      counts.total += count;
+    });
+
+    res.status(200).json({
+      success: true,
+      data: {
+        articleId,
+        stats: counts
+      }
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Erreur lors de la récupération des statistiques:', error);
+    res.status(500).json({
+      success: false,
+      data: {
+        articleId: req.params.articleId,
+        stats: {
+          like: 0,
+          love: 0,
+          care: 0,
+          haha: 0,
+          wow: 0,
+          sad: 0,
+          angry: 0,
+          total: 0
+        }
+      }
+    });
+  }
+};

--- a/server/src/db/sequelize.ts
+++ b/server/src/db/sequelize.ts
@@ -4,6 +4,7 @@ import { initUserModel } from '../models/User';
 import { initSessionModel } from '../models/Session';
 import { initCategoryModel } from '../models/Category';
 import { initArticleModel } from '../models/Article';
+import { initLikeArticleModel } from '../models/LikeArticle';
 import { setupAssociations } from '../models/associations';
 
 // Configuration pour les tests (mémoire) vs production (fichier)
@@ -22,6 +23,7 @@ export async function initDatabase(): Promise<void> {
     initSessionModel(sequelize);
     initCategoryModel(sequelize);
     initArticleModel(sequelize);
+    initLikeArticleModel(sequelize);
     
     // Configurer les associations après l'initialisation des modèles
     setupAssociations(sequelize);

--- a/server/src/models/LikeArticle.ts
+++ b/server/src/models/LikeArticle.ts
@@ -1,0 +1,89 @@
+import { DataTypes, Model, Optional, Sequelize } from 'sequelize';
+
+// Interface pour les attributs de LikeArticle
+export interface LikeArticleAttributes {
+  id: string;
+  userId: string;
+  articleId: string;
+  type: 'like' | 'love' | 'care' | 'haha' | 'wow' | 'sad' | 'angry';
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+// Interface pour les attributs optionnels lors de la création
+export interface LikeArticleCreationAttributes extends Optional<LikeArticleAttributes, 'id' | 'createdAt' | 'updatedAt'> {}
+
+// Classe du modèle LikeArticle
+export class LikeArticle extends Model<LikeArticleAttributes, LikeArticleCreationAttributes> implements LikeArticleAttributes {
+  public id!: string;
+  public userId!: string;
+  public articleId!: string;
+  public type!: 'like' | 'love' | 'care' | 'haha' | 'wow' | 'sad' | 'angry';
+  public readonly createdAt!: Date;
+  public readonly updatedAt!: Date;
+}
+
+// Fonction d'initialisation du modèle
+export function initLikeArticleModel(sequelize: Sequelize): void {
+  LikeArticle.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+        allowNull: false
+      },
+      userId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        references: {
+          model: 'users',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      articleId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        references: {
+          model: 'articles',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      type: {
+        type: DataTypes.ENUM('like', 'love', 'care', 'haha', 'wow', 'sad', 'angry'),
+        allowNull: false,
+        validate: {
+          isIn: [['like', 'love', 'care', 'haha', 'wow', 'sad', 'angry']]
+        }
+      }
+    },
+    {
+      sequelize,
+      modelName: 'LikeArticle',
+      tableName: 'like_articles',
+      timestamps: true,
+      paranoid: false,
+      indexes: [
+        {
+          fields: ['userId']
+        },
+        {
+          fields: ['articleId']
+        },
+        {
+          fields: ['type']
+        },
+        {
+          unique: true,
+          fields: ['userId', 'articleId'] // Un utilisateur ne peut liker qu'une fois un article
+        }
+      ]
+    }
+  );
+}
+
+export default LikeArticle;

--- a/server/src/models/associations.ts
+++ b/server/src/models/associations.ts
@@ -4,6 +4,7 @@ export function setupAssociations(sequelize: Sequelize): void {
   const { User } = sequelize.models;
   const { Category } = sequelize.models;
   const { Article } = sequelize.models;
+  const { LikeArticle } = sequelize.models;
 
   // Association User -> Article (One-to-Many)
   User.hasMany(Article, {
@@ -23,5 +24,25 @@ export function setupAssociations(sequelize: Sequelize): void {
   Article.belongsTo(Category, {
     foreignKey: 'categoryId',
     as: 'Category'
+  });
+
+  // Association User -> LikeArticle (One-to-Many)
+  User.hasMany(LikeArticle, {
+    foreignKey: 'userId',
+    as: 'LikeArticles'
+  });
+  LikeArticle.belongsTo(User, {
+    foreignKey: 'userId',
+    as: 'User'
+  });
+
+  // Association Article -> LikeArticle (One-to-Many)
+  Article.hasMany(LikeArticle, {
+    foreignKey: 'articleId',
+    as: 'LikeArticles'
+  });
+  LikeArticle.belongsTo(Article, {
+    foreignKey: 'articleId',
+    as: 'Article'
   });
 }

--- a/server/src/routes/likeArticle.routes.ts
+++ b/server/src/routes/likeArticle.routes.ts
@@ -1,0 +1,73 @@
+import { Router } from 'express';
+import {
+  createLikeArticle,
+  getLikeArticles,
+  getLikeArticleById,
+  updateLikeArticle,
+  deleteLikeArticle,
+  getArticleLikeStats
+} from '../controllers/likeArticle.controllers';
+import {
+  createLikeArticleSchema,
+  updateLikeArticleSchema,
+  getLikeArticlesQuerySchema,
+  likeArticleIdParamSchema,
+  articleIdParamSchema
+} from '../schemas/likeArticle.schemas';
+import { validate, asyncHandler } from '../middleware/validation';
+import { authenticate } from '../middleware/auth';
+import { articleAuthorOrAdminScope } from '../middleware/scope';
+
+const router = Router();
+
+// Routes pour les likes d'articles
+
+// Obtenir tous les likes (sans protection)
+router.get(
+  '/',
+  validate(getLikeArticlesQuerySchema, 'query'),
+  asyncHandler(getLikeArticles)
+);
+
+// Obtenir un like par ID (sans protection)
+router.get(
+  '/:id',
+  validate(likeArticleIdParamSchema, 'params'),
+  asyncHandler(getLikeArticleById)
+);
+
+// Obtenir les statistiques de likes pour un article (sans protection)
+router.get(
+  '/stats/:articleId',
+  validate(articleIdParamSchema, 'params'),
+  asyncHandler(getArticleLikeStats)
+);
+
+// Créer un like (authentification requise)
+router.post(
+  '/',
+  authenticate,
+  validate(createLikeArticleSchema, 'body'),
+  asyncHandler(createLikeArticle)
+);
+
+// Mettre à jour un like (authentification requise, user ou admin)
+router.put(
+  '/:id',
+  authenticate,
+  articleAuthorOrAdminScope,
+  validate(likeArticleIdParamSchema, 'params'),
+  validate(updateLikeArticleSchema, 'body'),
+  asyncHandler(updateLikeArticle)
+);
+
+// Supprimer un like (authentification requise, user ou admin)
+router.delete(
+  '/:id',
+  authenticate,
+  articleAuthorOrAdminScope,
+  validate(likeArticleIdParamSchema, 'params'),
+  asyncHandler(deleteLikeArticle)
+);
+
+export default router;

--- a/server/src/schemas/likeArticle.schemas.ts
+++ b/server/src/schemas/likeArticle.schemas.ts
@@ -1,0 +1,106 @@
+import Joi from 'joi';
+
+// Schéma pour la création d'un like
+export const createLikeArticleSchema = Joi.object({
+  articleId: Joi.string()
+    .uuid()
+    .required()
+    .messages({
+      'string.guid': 'L\'ID de l\'article doit être un UUID valide',
+      'any.required': 'L\'ID de l\'article est requis'
+    }),
+  type: Joi.string()
+    .valid('like', 'love', 'care', 'haha', 'wow', 'sad', 'angry')
+    .required()
+    .messages({
+      'any.only': 'Le type doit être like, love, care, haha, wow, sad ou angry',
+      'any.required': 'Le type est requis'
+    })
+});
+
+// Schéma pour la mise à jour d'un like
+export const updateLikeArticleSchema = Joi.object({
+  type: Joi.string()
+    .valid('like', 'love', 'care', 'haha', 'wow', 'sad', 'angry')
+    .required()
+    .messages({
+      'any.only': 'Le type doit être like, love, care, haha, wow, sad ou angry',
+      'any.required': 'Le type est requis'
+    })
+});
+
+// Schéma pour les paramètres de requête (pagination, recherche, filtres)
+export const getLikeArticlesQuerySchema = Joi.object({
+  page: Joi.number()
+    .integer()
+    .min(1)
+    .default(1)
+    .messages({
+      'number.base': 'La page doit être un nombre',
+      'number.integer': 'La page doit être un nombre entier',
+      'number.min': 'La page doit être supérieure ou égale à 1'
+    }),
+  limit: Joi.number()
+    .integer()
+    .min(1)
+    .max(100)
+    .default(10)
+    .messages({
+      'number.base': 'La limite doit être un nombre',
+      'number.integer': 'La limite doit être un nombre entier',
+      'number.min': 'La limite doit être supérieure ou égale à 1',
+      'number.max': 'La limite ne peut pas dépasser 100'
+    }),
+  type: Joi.string()
+    .valid('like', 'love', 'care', 'haha', 'wow', 'sad', 'angry')
+    .optional()
+    .messages({
+      'any.only': 'Le type doit être like, love, care, haha, wow, sad ou angry'
+    }),
+  articleId: Joi.string()
+    .uuid()
+    .optional()
+    .messages({
+      'string.guid': 'L\'ID de l\'article doit être un UUID valide'
+    }),
+  userId: Joi.string()
+    .uuid()
+    .optional()
+    .messages({
+      'string.guid': 'L\'ID de l\'utilisateur doit être un UUID valide'
+    }),
+  sortBy: Joi.string()
+    .valid('createdAt', 'updatedAt', 'type')
+    .default('createdAt')
+    .messages({
+      'any.only': 'Le tri doit être par createdAt, updatedAt ou type'
+    }),
+  sortOrder: Joi.string()
+    .valid('ASC', 'DESC')
+    .default('DESC')
+    .messages({
+      'any.only': 'L\'ordre de tri doit être ASC ou DESC'
+    })
+});
+
+// Schéma pour les paramètres d'ID
+export const likeArticleIdParamSchema = Joi.object({
+  id: Joi.string()
+    .uuid()
+    .required()
+    .messages({
+      'string.guid': 'L\'ID du like doit être un UUID valide',
+      'any.required': 'L\'ID du like est requis'
+    })
+});
+
+// Schéma pour les paramètres d'ID d'article
+export const articleIdParamSchema = Joi.object({
+  articleId: Joi.string()
+    .uuid()
+    .required()
+    .messages({
+      'string.guid': 'L\'ID de l\'article doit être un UUID valide',
+      'any.required': 'L\'ID de l\'article est requis'
+    })
+});


### PR DESCRIPTION
- Create LikeArticle model with id, userId, articleId, type fields
- Add 7 reaction types: like, love, care, haha, wow, sad, angry
- Implement unique constraint per user per article
- Add LikeArticle controller with CRUD operations
- Implement user-only access for own likes, admin access for all likes
- Add public access for read operations (GET endpoints)
- Create comprehensive validation schemas for all operations
- Add complete test suite (37 tests) for LikeArticle functionality
- Integrate LikeArticle routes into main application
- Update database initialization to include LikeArticle model and associations
- Add like statistics endpoint for articles
- Support like update when user already liked the same article
- Include search, pagination, and filtering capabilities

Features:
- GET /api/like-articles - List all likes (public)
- GET /api/like-articles/:id - Get like by ID (public)
- GET /api/like-articles/stats/:articleId - Get like statistics for article (public)
- POST /api/like-articles - Create/update like (authenticated users)
- PUT /api/like-articles/:id - Update like (author or admin)
- DELETE /api/like-articles/:id - Delete like (author or admin)
- Full relationship support with User and Article models
- Comprehensive error handling and validation
- Like statistics with counts per reaction type
- Automatic like update when user already liked article